### PR TITLE
spritz/snakemake GUI

### DIFF
--- a/CMDOptions/Options.cs
+++ b/CMDOptions/Options.cs
@@ -26,7 +26,7 @@ namespace CMD
         public string SpritzDirectory { get; set; } = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
 
         [Option('a', "analysisDirectory", Required = false, HelpText = "Target directory for downloads and analysis")]
-        public string AnalysisDirectory { get; set; } = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+        public string AnalysisDirectory { get; set; } = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "output");
 
         [Option('1', "fq1", Required = false, HelpText = "FASTQ file for single-end or for pair1 (comma-separated for multiple files)")]
         public string Fastq1 { get; set; }

--- a/GUI/EverythingRunnerEngine.cs
+++ b/GUI/EverythingRunnerEngine.cs
@@ -30,10 +30,6 @@ namespace SpritzGUI
 
         public void Run()
         {
-            //var startTimeForAllFilenames = DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss", CultureInfo.InvariantCulture);
-
-            //outputFolder = outputFolder.Replace("$DATETIME", startTimeForAllFilenames);
-
             for (int i = 0; i < taskList.Count; i++)
             {
                 var ok = taskList[i];
@@ -58,101 +54,6 @@ namespace SpritzGUI
                 var options = taskList[i].Item2;
                 yield return "docker pull rinaibrhm/spritz ; docker run --rm -t -i -v \"\"\"" + options.AnalysisDirectory + ":/app/data\"\"\" rinaibrhm/spritz";
             }
-        }
-
-        private string[] GenerateArguments(Options options)
-        {
-            List<string> commands = new List<string> { "-c", options.Command };
-            if (options.SpritzDirectory != null && options.SpritzDirectory != "")
-            {
-                commands.AddRange(new[] { "-b", AddQuotes(options.SpritzDirectory) });
-            }
-            if (options.AnalysisDirectory != null && options.AnalysisDirectory != "")
-            {
-                commands.AddRange(new[] { "-a", AddQuotes(options.AnalysisDirectory)});
-            }
-            if (options.Fastq1 != null && options.Fastq1 != "")
-            {
-                commands.AddRange(new[] { "--fq1", AddQuotes(options.Fastq1) });
-            }
-            if (options.Fastq2 != null && options.Fastq2 != "")
-            {
-                commands.AddRange(new[] { "--fq2", AddQuotes(options.Fastq2) });
-            }
-            if (options.ExperimentType != null && options.ExperimentType != "")
-            {
-                commands.AddRange(new[] { "-e", options.ExperimentType });
-            }
-            if (options.SraAccession != null && options.SraAccession != "")
-            {
-                commands.AddRange(new[] { "-s", options.SraAccession });
-            }
-            if (options.Threads > 0 && options.Threads <= Environment.ProcessorCount)
-            {
-                commands.AddRange(new[] { "-t", options.Threads.ToString() });
-            }
-            if (options.GenomeStarIndexDirectory != null && options.GenomeStarIndexDirectory != "")
-            {
-                commands.AddRange(new[] { "-d", AddQuotes(options.GenomeStarIndexDirectory) });
-            }
-            if (options.GenomeFasta != null && options.GenomeFasta != "")
-            {
-                commands.AddRange(new[] { "-f", AddQuotes(options.GenomeFasta) });
-            }
-            if (options.GeneModelGtfOrGff != null && options.GeneModelGtfOrGff != "")
-            {
-                commands.AddRange(new[] { "-g", AddQuotes(options.GeneModelGtfOrGff) });
-            }
-            if (options.NewGeneModelGtfOrGff != null && options.NewGeneModelGtfOrGff != "")
-            {
-                commands.AddRange(new[] { "-h", AddQuotes(options.NewGeneModelGtfOrGff) });
-            }
-            if (options.ReferenceVcf != null && options.ReferenceVcf != "")
-            {
-                commands.AddRange(new[] { "-v", AddQuotes(options.ReferenceVcf) });
-            }
-            if (options.Reference != null && options.Reference != "")
-            {
-                commands.AddRange(new[] { "-r", options.Reference });
-            }
-            if (options.UniProtXml != null && options.UniProtXml != "")
-            {
-                commands.AddRange(new[] { "-x", AddQuotes(options.UniProtXml) });
-            }
-            if (options.UniProtXml != null && options.UniProtXml != "")
-            {
-                commands.AddRange(new[] { "--indelFinder", options.IndelFinder });
-            }
-            if (options.OverwriteStarAlignments)
-            {
-                commands.Add("--overwriteStarAlignments");
-            }
-            if (options.StrandSpecific)
-            {
-                commands.Add("--strandSpecific");
-            }
-            if (options.InferStrandSpecificity)
-            {
-                commands.Add("--inferStrandedness");
-            }
-            if (options.DoTranscriptIsoformAnalysis)
-            {
-                commands.Add("--doTranscriptIsoformAnalysis");
-            }
-            if (options.DoFusionAnalysis)
-            {
-                commands.Add("--doGeneFusionAnalysis");
-            }
-            if (options.SkipVariantAnalysis)
-            {
-                commands.Add("--skipVariantAnalysis");
-            }
-            if (options.VariantCallingWorkers > 0 && options.VariantCallingWorkers <= Environment.ProcessorCount)
-            {
-                commands.AddRange(new[] { "--variantCallingWorkers", options.VariantCallingWorkers.ToString() });
-            }
-            
-            return commands.ToArray();
         }
 
         private YamlSequenceNode AddParam(string[] items, YamlSequenceNode node)

--- a/GUI/EverythingRunnerEngine.cs
+++ b/GUI/EverythingRunnerEngine.cs
@@ -39,7 +39,7 @@ namespace SpritzGUI
 
                 Process proc = new Process();
                 proc.StartInfo.FileName = "Powershell.exe";
-                proc.StartInfo.Arguments = "docker pull rinaibrhm/spritz ; docker run --rm -t -i -v \"\"\"" + ok.Item2.AnalysisDirectory + ":/app/data\"\"\" rinaibrhm/spritz ls /app/data";
+                proc.StartInfo.Arguments = "docker pull rinaibrhm/spritz ; docker run --rm -t -i -v \"\"\"" + ok.Item2.AnalysisDirectory + ":/app/data\"\"\" rinaibrhm/spritz";
                 proc.StartInfo.CreateNoWindow = true;
                 proc.StartInfo.UseShellExecute = false;
                 proc.StartInfo.RedirectStandardError = true;
@@ -54,7 +54,7 @@ namespace SpritzGUI
             for (int i = 0; i < taskList.Count; i++)
             {
                 var options = taskList[i].Item2;
-                yield return "docker pull rinaibrhm/spritz ; docker run --rm -t -i -v \"\"\"" + options.AnalysisDirectory + ":/app/data\"\"\" rinaibrhm/spritz ls /app/data";
+                yield return "docker pull rinaibrhm/spritz ; docker run --rm -t -i -v \"\"\"" + options.AnalysisDirectory + ":/app/data\"\"\" rinaibrhm/spritz";
             }
         }
 
@@ -192,7 +192,7 @@ namespace SpritzGUI
             {
                 if (fastq.Length > 0)
                 {
-                    accession.Add(fastq);
+                    fq1.Add(fastq);
                 }
             }
             rootMappingNode.Add("fq1", fq1);
@@ -203,18 +203,21 @@ namespace SpritzGUI
             {
                 if (fastq.Length > 0)
                 {
-                    accession.Add(fastq);
+                    fq2.Add(fastq);
                 }
             }
             rootMappingNode.Add("fq2", fq2);
 
-            Directory.SetCurrentDirectory(options.AnalysisDirectory);
-
-            // edit directory
+            Directory.SetCurrentDirectory(options.AnalysisDirectory); // switch to analysis directory for writing permissions
+    
+            // add config file to user defined analysis directory, will mount to docker container
             using (TextWriter writer = File.CreateText(Path.Combine(Directory.GetCurrentDirectory(), "config.yaml")))
             {
                 stream.Save(writer, false);
             }
+
+            // switch back to current directory
+            Directory.SetCurrentDirectory(SpritzDirectory);
         }
 
         /// <summary>

--- a/GUI/EverythingRunnerEngine.cs
+++ b/GUI/EverythingRunnerEngine.cs
@@ -153,6 +153,20 @@ namespace SpritzGUI
             return commands.ToArray();
         }
 
+        private YamlSequenceNode AddParam(string[] items, YamlSequenceNode node)
+        {
+            node.Style = SequenceStyle.Flow;
+            foreach (string item in items)
+            {
+                if (item.Length > 0)
+                {
+                    node.Add(item);
+                }
+            }
+
+            return node;
+        }
+
         private void WriteConfig(Options options)
         {
             const string initialContent = "---\nversion: 1\n"; // needed to start writing yaml file
@@ -169,15 +183,7 @@ namespace SpritzGUI
 
             // write user input sras
             var accession = new YamlSequenceNode();
-            accession.Style = SequenceStyle.Flow;
-            foreach (string sra in sras)
-            {
-                if (sra.Length > 0)
-                {
-                    accession.Add(sra);
-                }
-            }
-            rootMappingNode.Add("sra", accession);
+            rootMappingNode.Add("sra", AddParam(sras, accession));
 
             // write user defined analysis directory (input and output folder)
             var analysisDirectory = new YamlSequenceNode();
@@ -187,26 +193,9 @@ namespace SpritzGUI
 
             // write user input fastqs
             var fq1 = new YamlSequenceNode();
-            fq1.Style = SequenceStyle.Flow;
-            foreach (string fastq in fq1s)
-            {
-                if (fastq.Length > 0)
-                {
-                    fq1.Add(fastq);
-                }
-            }
-            rootMappingNode.Add("fq1", fq1);
-
+            rootMappingNode.Add("fq1", AddParam(fq1s, fq1));
             var fq2 = new YamlSequenceNode();
-            fq2.Style = SequenceStyle.Flow;
-            foreach (string fastq in fq2s)
-            {
-                if (fastq.Length > 0)
-                {
-                    fq2.Add(fastq);
-                }
-            }
-            rootMappingNode.Add("fq2", fq2);
+            rootMappingNode.Add("fq2", AddParam(fq2s, fq2));
 
             Directory.SetCurrentDirectory(options.AnalysisDirectory); // switch to analysis directory for writing permissions
     

--- a/GUI/EverythingRunnerEngine.cs
+++ b/GUI/EverythingRunnerEngine.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Text;
 using YamlDotNet.Core.Events;
 using YamlDotNet.RepresentationModel;
-using YamlDotNet.Serialization;
 
 namespace SpritzGUI
 {
@@ -42,7 +41,7 @@ namespace SpritzGUI
 
                 Process proc = new Process();
                 proc.StartInfo.FileName = "Powershell.exe";
-                proc.StartInfo.Arguments = "docker pull rinaibrhm/spritz ; docker run --rm -t -i -v \"\"\"" + ok.Item2.AnalysisDirectory + ":/app/" + AnalysisDirectory + "\"\"\" -v \"\"\"" + ConfigDirectory + ":/app/configs\"\"\" rinaibrhm /spritz";
+                proc.StartInfo.Arguments = "docker pull rinaibrhm/spritz ; docker run --rm -t -i --name spritz -v \"\"\"" + ok.Item2.AnalysisDirectory + ":/app/" + AnalysisDirectory + "\"\"\" -v \"\"\"" + ConfigDirectory + ":/app/configs\"\"\" rinaibrhm/spritz";
                 proc.StartInfo.CreateNoWindow = true;
                 proc.StartInfo.UseShellExecute = false;
                 proc.StartInfo.RedirectStandardError = true;

--- a/GUI/MainWindow.xaml
+++ b/GUI/MainWindow.xaml
@@ -148,6 +148,7 @@
                         </TreeView>
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Grid.Row="2">
                             <Button x:Name="ClearTasksButton" Content="Clear" Click="ClearTasksButton_Click" />
+                            <Button x:Name="ResetTasksButton" Content="Reset Tasks" Click="ResetTasksButton_Click" />
                         </StackPanel>
                         <DockPanel Margin="5" Grid.Row="3" LastChildFill="True">
                             <Label Content="Output Folder:" />

--- a/GUI/MainWindow.xaml
+++ b/GUI/MainWindow.xaml
@@ -108,7 +108,7 @@
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Grid.Row="1">
                             <Button x:Name="BtnAddRnaSeqFastq" Content="Add" Click="BtnAddRnaSeqFastq_Click" />
                             <Button x:Name="BtnClearRnaSeqFastq" Content="Clear" Click="BtnClearRnaSeqFastq_Click" />
-                            <Button x:Name="BtnSaveRnaSeqFastqSet" Content="Save" Click="BtnSaveRnaSeqFastqSet_Click"/>
+                            <!--<Button x:Name="BtnSaveRnaSeqFastqSet" Content="Save" Click="BtnSaveRnaSeqFastqSet_Click"/>-->
                         </StackPanel>
                     </Grid>
                 </GroupBox>

--- a/GUI/MainWindow.xaml
+++ b/GUI/MainWindow.xaml
@@ -136,27 +136,24 @@
                         </StackPanel>
                         <TreeView x:Name="workflowTreeView" Grid.Row="1" ItemsSource="{Binding}" MouseDoubleClick="workflowTreeView_MouseDoubleClick">
                             <TreeView.Resources>
-                                <HierarchicalDataTemplate DataType="{x:Type local:CollectionForTreeView}" ItemsSource="{Binding Children}">
+                                <!--<HierarchicalDataTemplate DataType="{x:Type local:CollectionForTreeView}" ItemsSource="{Binding Children}">
                                     <StackPanel Orientation="Horizontal">
                                         <TextBlock Text="C " />
                                         <TextBlock Text="{Binding DisplayName}" />
                                         <ProgressBar Value="{Binding Progress}" IsIndeterminate="{Binding IsIndeterminate}" Width="100" Margin="5,0,5,0" />
                                         <TextBlock Text="{Binding Status}" />
                                     </StackPanel>
-                                </HierarchicalDataTemplate>
+                                </HierarchicalDataTemplate>-->
                             </TreeView.Resources>
                         </TreeView>
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Grid.Row="2">
-                            <Button x:Name="LoadTaskButton" Content="Load" Click="LoadTaskButton_Click" />
                             <Button x:Name="ClearTasksButton" Content="Clear" Click="ClearTasksButton_Click" />
-                            <Button x:Name="RemoveLastTaskButton" Content="Remove Last Task" Click="RemoveLastTaskButton_Click" />
-                            <Button x:Name="ResetTasksButton" Content="Reset Tasks" Click="ResetTasksButton_Click" />
                         </StackPanel>
                         <DockPanel Margin="5" Grid.Row="3" LastChildFill="True">
                             <Label Content="Output Folder:" />
-                            <TextBox x:Name="OutputFolderTextBox" ToolTip="$DATETIME is automatically replaced by the current date and time" />
+                            <TextBox x:Name="OutputFolderTextBox" ToolTip="$DATETIME is automatically replaced by the current date and time" IsEnabled="False" />
                         </DockPanel>
-                        <Button x:Name="RunWorkflowButton" Content="Run workflows!" Click="RunWorkflowButton_Click" FontSize="12" Grid.Row="4" />
+                        <Button x:Name="RunWorkflowButton" Content="Run workflow!" Click="RunWorkflowButton_Click" FontSize="12" Grid.Row="4" />
                     </Grid>
                 </GroupBox>
                 <GridSplitter Grid.Row="1" VerticalAlignment="Center" HorizontalAlignment="Stretch" Background="Silver" Height="5"/>

--- a/GUI/MainWindow.xaml.cs
+++ b/GUI/MainWindow.xaml.cs
@@ -34,8 +34,8 @@ namespace SpritzGUI
             DataGridRnaSeqFastq.DataContext = RnaSeqFastqCollection;
             workflowTreeView.DataContext = StaticTasksObservableCollection;
             LbxSRAs.ItemsSource = SraCollection;
-            if (!InstallationDialogAndCheck())
-                Close();
+            //if (!InstallationDialogAndCheck())
+            //    Close();
         }
 
         protected override void OnClosed(EventArgs e)
@@ -239,14 +239,20 @@ namespace SpritzGUI
         {
             if (TbxSRA.Text.Contains("SR"))
             {
-                if (SraCollection.Any(s => s.Name == TbxSRA.Text))
+                // temporary: only allow for one sra
+                if (SraCollection.Count > 0)
                 {
-                    MessageBox.Show("That SRA has already been added. Please choose a new SRA accession.", "Workflow", MessageBoxButton.OK, MessageBoxImage.Information);
+                    MessageBox.Show("Only one SRA can be added.", "Workflow", MessageBoxButton.OK, MessageBoxImage.Information);
                 }
+                //if (SraCollection.Any(s => s.Name == TbxSRA.Text))
+                //{
+                //    MessageBox.Show("That SRA has already been added. Please choose a new SRA accession.", "Workflow", MessageBoxButton.OK, MessageBoxImage.Information);
+                //}
                 else
                 { 
                     SRADataGrid sraDataGrid = new SRADataGrid(TbxSRA.Text);
                     SraCollection.Add(sraDataGrid);
+                    BtnAddSRA.IsEnabled = false;
                 }
             }
             else if (MessageBox.Show("SRA accessions are expected to start with \"SR\", such as SRX254398 or SRR791584. View the GEO SRA website?", "Workflow", MessageBoxButton.YesNo, MessageBoxImage.Question, MessageBoxResult.No) == MessageBoxResult.Yes)
@@ -258,6 +264,7 @@ namespace SpritzGUI
         private void BtnClearSRA_Click(object sender, RoutedEventArgs e)
         {
             SraCollection.Clear();
+            BtnAddSRA.IsEnabled = true;
         }
 
         private void BtnWorkFlow_Click(object sender, RoutedEventArgs e)

--- a/GUI/MainWindow.xaml.cs
+++ b/GUI/MainWindow.xaml.cs
@@ -42,12 +42,13 @@ namespace SpritzGUI
         {
             // TODO: implement some way of killing EverythingTask
 
-            // new process that kills docker container
+            // new process that kills docker container (if any)
             Process proc = new Process();
             proc.StartInfo.FileName = "Powershell.exe";
-            proc.StartInfo.Arguments = "docker ps -a; docker kill spritz";
-
-            proc.StartInfo.UseShellExecute = true;
+            proc.StartInfo.Arguments = "docker kill spritz";
+            proc.StartInfo.CreateNoWindow = true;
+            proc.StartInfo.UseShellExecute = false;
+            proc.StartInfo.RedirectStandardError = true;
             proc.Start();
 
             if (proc != null && !proc.HasExited)

--- a/GUI/MainWindow.xaml.cs
+++ b/GUI/MainWindow.xaml.cs
@@ -96,7 +96,8 @@ namespace SpritzGUI
             }
             workflowTreeView.DataContext = DynamicTasksObservableCollection;
             Everything = new EverythingRunnerEngine(DynamicTasksObservableCollection.Select(b => new Tuple<string, Options>(b.DisplayName, b.options)).ToList(), OutputFolderTextBox.Text);
-            WarningsTextBox.AppendText(string.Join("\n", Everything.GenerateCommandsDry().Select(x => $"Command executing: CMD.exe {x}"))); // keep for debugging
+            //WarningsTextBox.AppendText(string.Join("\n", Everything.GenerateCommandsDry().Select(x => $"Command executing: CMD.exe {x}"))); // keep for debugging
+            WarningsTextBox.AppendText(string.Join("\n", Everything.GenerateCommandsDry().Select(x => $"Command executing: Powershell.exe {x}"))); // keep for debugging
             var t = new Task(Everything.Run);
             t.Start();
             t.ContinueWith(DisplayAnyErrors);
@@ -184,23 +185,23 @@ namespace SpritzGUI
             UpdateTaskGuiStuff();
         }
 
-        private void RemoveLastTaskButton_Click(object sender, RoutedEventArgs e)
-        {
-            StaticTasksObservableCollection.RemoveAt(StaticTasksObservableCollection.Count - 1);
-            UpdateTaskGuiStuff();
-        }
+        //private void RemoveLastTaskButton_Click(object sender, RoutedEventArgs e)
+        //{
+        //    StaticTasksObservableCollection.RemoveAt(StaticTasksObservableCollection.Count - 1);
+        //    UpdateTaskGuiStuff();
+        //}
 
-        private void ResetTasksButton_Click(object sender, RoutedEventArgs e)
-        {
-            RunWorkflowButton.IsEnabled = true;
-            ResetTasksButton.IsEnabled = false;
-            for (int i = 0; i < DynamicTasksObservableCollection.Count; i++)
-            {
-                StaticTasksObservableCollection.Add(new PreRunTask(StaticTasksObservableCollection[i].options));
-            }
-            DynamicTasksObservableCollection.Clear();
-            workflowTreeView.DataContext = StaticTasksObservableCollection;
-        }
+        //private void ResetTasksButton_Click(object sender, RoutedEventArgs e)
+        //{
+        //    RunWorkflowButton.IsEnabled = true;
+        //    ResetTasksButton.IsEnabled = false;
+        //    for (int i = 0; i < DynamicTasksObservableCollection.Count; i++)
+        //    {
+        //        StaticTasksObservableCollection.Add(new PreRunTask(StaticTasksObservableCollection[i].options));
+        //    }
+        //    DynamicTasksObservableCollection.Clear();
+        //    workflowTreeView.DataContext = StaticTasksObservableCollection;
+        //}
 
         private void AddNewRnaSeqFastq(object sender, StringListEventArgs e)
         {
@@ -239,20 +240,14 @@ namespace SpritzGUI
         {
             if (TbxSRA.Text.Contains("SR"))
             {
-                // temporary: only allow for one sra
-                if (SraCollection.Count > 0)
+                if (SraCollection.Any(s => s.Name == TbxSRA.Text))
                 {
-                    MessageBox.Show("Only one SRA can be added.", "Workflow", MessageBoxButton.OK, MessageBoxImage.Information);
+                    MessageBox.Show("That SRA has already been added. Please choose a new SRA accession.", "Workflow", MessageBoxButton.OK, MessageBoxImage.Information);
                 }
-                //if (SraCollection.Any(s => s.Name == TbxSRA.Text))
-                //{
-                //    MessageBox.Show("That SRA has already been added. Please choose a new SRA accession.", "Workflow", MessageBoxButton.OK, MessageBoxImage.Information);
-                //}
                 else
                 { 
                     SRADataGrid sraDataGrid = new SRADataGrid(TbxSRA.Text);
                     SraCollection.Add(sraDataGrid);
-                    BtnAddSRA.IsEnabled = false;
                 }
             }
             else if (MessageBox.Show("SRA accessions are expected to start with \"SR\", such as SRX254398 or SRR791584. View the GEO SRA website?", "Workflow", MessageBoxButton.YesNo, MessageBoxImage.Question, MessageBoxResult.No) == MessageBoxResult.Yes)
@@ -302,15 +297,14 @@ namespace SpritzGUI
             if (StaticTasksObservableCollection.Count == 0)
             {
                 RunWorkflowButton.IsEnabled = false;
-                RemoveLastTaskButton.IsEnabled = false;
                 ClearTasksButton.IsEnabled = false;
-                ResetTasksButton.IsEnabled = false;
+                BtnWorkFlow.IsEnabled = true;
             }
             else
             {
                 RunWorkflowButton.IsEnabled = true;
-                RemoveLastTaskButton.IsEnabled = true;
                 ClearTasksButton.IsEnabled = true;
+                BtnWorkFlow.IsEnabled = false;
             }
         }
 
@@ -367,24 +361,24 @@ namespace SpritzGUI
             }
         }
 
-        private bool InstallationDialogAndCheck()
-        {
-            var exePath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+        //private bool InstallationDialogAndCheck()
+        //{
+        //    var exePath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
 
-            if (!WrapperUtility.CheckToolSetup(exePath))
-            {
-                try
-                {
-                    var dialog = new InstallWindow();
-                    dialog.ShowDialog();
-                }
-                catch (Exception ex)
-                {
-                    MessageBox.Show(ex.ToString(), "Installation", MessageBoxButton.OK, MessageBoxImage.Error);
-                }
-            }
-            return WrapperUtility.CheckBashSetup() && WrapperUtility.CheckToolSetup(Environment.CurrentDirectory);
-        }
+        //    if (!WrapperUtility.CheckToolSetup(exePath))
+        //    {
+        //        try
+        //        {
+        //            var dialog = new InstallWindow();
+        //            dialog.ShowDialog();
+        //        }
+        //        catch (Exception ex)
+        //        {
+        //            MessageBox.Show(ex.ToString(), "Installation", MessageBoxButton.OK, MessageBoxImage.Error);
+        //        }
+        //    }
+        //    return WrapperUtility.CheckBashSetup() && WrapperUtility.CheckToolSetup(Environment.CurrentDirectory);
+        //}
 
         private void WriteExperDesignToTsv(string filePath)
         {

--- a/GUI/SpritzGUI.csproj
+++ b/GUI/SpritzGUI.csproj
@@ -53,6 +53,9 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
+    <Reference Include="YamlDotNet, Version=6.0.0.0, Culture=neutral, PublicKeyToken=ec19458f3c15af5e, processorArchitecture=MSIL">
+      <HintPath>..\packages\YamlDotNet.6.0.0\lib\net45\YamlDotNet.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">

--- a/GUI/WorkFlow.xaml
+++ b/GUI/WorkFlow.xaml
@@ -5,7 +5,6 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:SpritzGUI"
         mc:Ignorable="d"
-        Drop="Window_Drop" AllowDrop="True"
         Title="WorkFlow Windows" Height="450" Width="800">
     <Grid>
         <Grid.RowDefinitions>
@@ -15,7 +14,7 @@
         </Grid.RowDefinitions>
         <StackPanel  Orientation="Horizontal" HorizontalAlignment="Center" Grid.Row="0"  Margin="5">
             <Label Content="Select Work Flow Type"/>
-            <ComboBox x:Name="CbxWorkFlowType"/>
+            <ComboBox x:Name="CbxWorkFlowType" IsEnabled="False"/>
         </StackPanel>
         <ScrollViewer VerticalScrollBarVisibility="Auto" Grid.Row="1">
             <DockPanel>
@@ -58,16 +57,16 @@
                             <Label Content="sraAcession" Width="200"/>
                             <TextBox x:Name="txtSraAcession" Width="180" />
                         </StackPanel>-->
-                        <StackPanel  Orientation="Horizontal" Grid.Row="4" Grid.Column="0">
-                            <Label Content="Experiment Type"/>
-                            <ComboBox x:Name="CmbxExperimentType"/>
+                        <StackPanel  Orientation="Horizontal" Grid.Row="2" Grid.Column="0">
+                            <Label Content="Experiment Type" Width="200"/>
+                            <ComboBox x:Name="CmbxExperimentType" IsEnabled="False" Width="180"/>
                         </StackPanel>
-                        <StackPanel Orientation="Horizontal" Grid.Row="5" Grid.Column="0">
+                        <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="0">
                             <Label Content="Threads" Width="200"/>
-                            <TextBox x:Name="txtThreads" TextChanged="txtThreads_TextChanged" Width="180" />
+                            <TextBox x:Name="txtThreads" TextChanged="txtThreads_TextChanged" Width="180" IsEnabled="False"/>
                         </StackPanel>
-                        <StackPanel Orientation="Horizontal" Grid.Row="6" Grid.Column="0">
-                            <Label Content="Star Genome Directory" Width="200"/>
+                        <!--<StackPanel Orientation="Horizontal" Grid.Row="6" Grid.Column="0">
+                            <Label Content="] Genome Directory" Width="200"/>
                             <TextBox x:Name="txtGenomeDir" Width="180" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Grid.Row="7" Grid.Column="0">
@@ -85,21 +84,32 @@
                         <StackPanel Orientation="Horizontal" Grid.Row="10" Grid.Column="0">
                             <Label Content="Protein Fasta Path" Width="200"/>
                             <TextBox x:Name="txtProteinFasta" Width="180" Height="32" VerticalAlignment="Bottom" />
-                        </StackPanel>
+                        </StackPanel>-->
 
-                        <StackPanel Orientation="Horizontal" Grid.Row="0" Grid.Column="1">
+                        <!--<StackPanel Orientation="Horizontal" Grid.Row="0" Grid.Column="1">
                             <Label Content="dbSNP VCF Reference" Width="200"/>
-                            <TextBox x:Name="txtDbsnpVcfReference" Width="180" />
-                        </StackPanel>
+                            <TextBox x:Name="txtDbsnpVcfReference" Width="180"/>
+                        </StackPanel>-->
                         <StackPanel Orientation="Horizontal" Grid.Row="1" Grid.Column="1">
                             <Label Content="Ensembl Reference" Width="200"/>
-                            <TextBox x:Name="txtEnsemblReference" Width="180" TextChanged="txtStarFusionReference_TextChanged" />
+                            <TextBox x:Name="txtEnsemblReference" Width="180" IsEnabled="False"/>
                         </StackPanel>
-                        <StackPanel Orientation="Horizontal" Grid.Row="2" Grid.Column="1">
+                        <StackPanel  Orientation="Horizontal" Grid.Row="2" Grid.Column="1">
+                            <Label Content="Indel Finding Software" Width="200"/>
+                            <ComboBox x:Name="CmbxIndelFinding" SelectionChanged="CmbxIndelFinding_SelectionChanged" IsEnabled="False"/>
+                        </StackPanel>
+                        <StackPanel  Orientation="Horizontal" Grid.Row="3" Grid.Column="1">
+                            <Label Content="Variant Caller Workers" Width="200"/>
+                            <TextBox x:Name="TxtVariantCallingWorkerNum" x:FieldModifier="private" Width="180" Text="0" IsEnabled="False"/>
+                            <!--<Button x:Name="CmdUpVariantCallingWorkers" x:FieldModifier="private" Margin="5,5,0,5" Content="˄" Width="20" Click="CmdUpVariantCallingWorkers_Click" />
+                            <Button x:Name="CmdDownVariantCallingWorkers" x:FieldModifier="private" Margin="0,5,0,5"  Content="˅" Width="20" Click="CmdDownVariantCallingWorkers_Click" />-->
+                        </StackPanel>
+                        
+                        <!--<StackPanel Orientation="Horizontal" Grid.Row="2" Grid.Column="1">
                             <Label Content="UniProt Protein XML" Width="200"/>
                             <TextBox x:Name="txtUniProtProteinXml" Width="180" />
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="1">
+                        </StackPanel>-->
+                        <!--<StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="1">
                             <Label Content="Overwrite Star Alignments" Width="200"/>
                             <CheckBox x:Name="ckbOverWriteStarAlignment" VerticalAlignment="Center" />
                         </StackPanel>
@@ -114,25 +124,15 @@
                         <StackPanel Orientation="Horizontal" Grid.Row="6" Grid.Column="1">
                             <Label Content="Skip Variant Analysis" Width="200"/>
                             <CheckBox x:Name="CkbSkipVariantAnalysis" Width="180"/>
-                        </StackPanel>
-                        <StackPanel  Orientation="Horizontal" Grid.Row="7" Grid.Column="1">
-                            <Label Content="Indel Finding Software"/>
-                            <ComboBox x:Name="CmbxIndelFinding" SelectionChanged="CmbxIndelFinding_SelectionChanged"/>
-                        </StackPanel>
-                        <StackPanel  Orientation="Horizontal" Grid.Row="8" Grid.Column="1">
-                            <Label Content="Variant Caller Workers"/>
-                            <TextBox x:Name="TxtVariantCallingWorkerNum" x:FieldModifier="private" Margin="5,5,0,5" Width="50" Text="0" TextChanged="TxtVariantCallingWorkerNum_TextChanged" />
-                            <Button x:Name="CmdUpVariantCallingWorkers" x:FieldModifier="private" Margin="5,5,0,5" Content="˄" Width="20" Click="CmdUpVariantCallingWorkers_Click" />
-                            <Button x:Name="CmdDownVariantCallingWorkers" x:FieldModifier="private" Margin="0,5,0,5"  Content="˅" Width="20" Click="CmdDownVariantCallingWorkers_Click" />
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal" Grid.Row="9" Grid.Column="1">
+                        </StackPanel>-->
+                        <!--<StackPanel Orientation="Horizontal" Grid.Row="9" Grid.Column="1">
                             <Label Content="Do Transcript Isoform Analysis" Width="200"/>
                             <CheckBox x:Name="CkbDoTranscriptIsoformAnalysis" Width="180" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Grid.Row="10" Grid.Column="1">
                             <Label Content="Do Gene Fusion Analysis" Width="200"/>
                             <CheckBox x:Name="CkbDoGeneFusionAnalysis" Width="180" />
-                        </StackPanel>
+                        </StackPanel>-->
                     </Grid>
                 </GroupBox>
             </DockPanel>

--- a/GUI/WorkFlow.xaml.cs
+++ b/GUI/WorkFlow.xaml.cs
@@ -123,10 +123,17 @@ namespace SpritzGUI
             }
 
             // Options.SpritzDirectory = txtSpritzDirecory.Text;
+            var defaultAnalysisDirectory = Path.Combine(Directory.GetCurrentDirectory(), "output");
+            if (!Directory.Exists(defaultAnalysisDirectory))
+            {
+                Directory.CreateDirectory(defaultAnalysisDirectory);
+            }
+
             Options.AnalysisDirectory = TrimQuotesOrNull(txtAnalysisDirectory.Text);
 
             if (!Directory.Exists(Options.AnalysisDirectory))
             {
+
                 MessageBox.Show("Analysis directory does not exist.", "Workflow", MessageBoxButton.OK);
                 return;
             }

--- a/GUI/WorkFlow.xaml.cs
+++ b/GUI/WorkFlow.xaml.cs
@@ -53,7 +53,7 @@ namespace SpritzGUI
         }
 
         protected void SaveButton_Click(object sender, RoutedEventArgs e)
-        {
+        {           
             // Command selection
             int i = CbxWorkFlowType.SelectedIndex;
             if (i == 0)
@@ -205,6 +205,19 @@ namespace SpritzGUI
             var rnaSeqFastqCollection = (ObservableCollection<RNASeqFastqDataGrid>)MainWindow.DataGridRnaSeqFastq.DataContext;
             Options.Fastq1 = string.Join(",", rnaSeqFastqCollection.Where(p => p.MatePair == 1.ToString()).OrderBy(p => p.FileName).Select(p => p.FileName.Substring(0, p.FileName.Length - 2)).ToArray());
             Options.Fastq2 = string.Join(",", rnaSeqFastqCollection.Where(p => p.MatePair == 2.ToString()).OrderBy(p => p.FileName).Select(p => p.FileName.Substring(0, p.FileName.Length - 2)).ToArray());
+
+            //use RNAFastqCollection instead
+            var fq1s = Options.Fastq1.Split(',') ?? new string[0];
+            var fq2s = Options.Fastq2.Split(',') ?? new string[0];
+
+            foreach (string fq1 in fq1s)
+            {
+                if (!fq2s.Any(fq2 => fq2.CompareTo(fq1) == 0))
+                {
+                    MessageBox.Show("Only paired end sequencing is supported. Add both paired files for " + fq1 + ".", "Run Workflows", MessageBoxButton.OK, MessageBoxImage.Information);
+                    throw new InvalidOperationException();
+                }
+            }
 
             Options.ExperimentType = CmbxExperimentType.SelectedItem.ToString();
             var sraCollection = (ObservableCollection<SRADataGrid>)MainWindow.LbxSRAs.ItemsSource;

--- a/GUI/WorkFlow.xaml.cs
+++ b/GUI/WorkFlow.xaml.cs
@@ -122,7 +122,7 @@ namespace SpritzGUI
                 return;
             }
 
-            //Options.SpritzDirectory = txtSpritzDirecory.Text;
+            // Options.SpritzDirectory = txtSpritzDirecory.Text;
             Options.AnalysisDirectory = TrimQuotesOrNull(txtAnalysisDirectory.Text);
 
             if (!Directory.Exists(Options.AnalysisDirectory))
@@ -132,73 +132,73 @@ namespace SpritzGUI
             }
 
             Options.Threads = int.Parse(txtThreads.Text);
-            Options.GenomeStarIndexDirectory = txtGenomeDir.Text;
-            Options.GenomeFasta = txtGenomeFasta.Text;
-            Options.GeneModelGtfOrGff = txtGeneModelGtfOrGff.Text;
-            Options.NewGeneModelGtfOrGff = txtNewGeneModelGtfOrGff.Text;
-            Options.ReferenceVcf = txtDbsnpVcfReference.Text;
-            Options.Reference = txtEnsemblReference.Text;
-            Options.UniProtXml = txtUniProtProteinXml.Text;
-            Options.OverwriteStarAlignments = ckbOverWriteStarAlignment.IsChecked.Value;
-            Options.StrandSpecific = ckbStrandSpecific.IsChecked.Value;
-            Options.InferStrandSpecificity = ckbInferStrandedness.IsChecked.Value;
-            Options.SkipVariantAnalysis = CkbSkipVariantAnalysis.IsChecked.Value;
-            Options.DoTranscriptIsoformAnalysis = CkbDoTranscriptIsoformAnalysis.IsChecked.Value;
-            Options.DoFusionAnalysis = CkbDoGeneFusionAnalysis.IsChecked.Value;
-            Options.VariantCallingWorkers = int.Parse(TxtVariantCallingWorkerNum.Text);
-            Options.ProteinFastaPath = txtProteinFasta.Text;
+
+            // features yet to be supported
+            //Options.GenomeStarIndexDirectory = txtGenomeDir.Text;
+            //Options.GenomeFasta = txtGenomeFasta.Text;
+            //Options.GeneModelGtfOrGff = txtGeneModelGtfOrGff.Text;
+            //Options.NewGeneModelGtfOrGff = txtNewGeneModelGtfOrGff.Text;
+            //Options.ReferenceVcf = txtDbsnpVcfReference.Text;
+            //Options.Reference = txtEnsemblReference.Text;
+            //Options.UniProtXml = txtUniProtProteinXml.Text;
+            //Options.OverwriteStarAlignments = ckbOverWriteStarAlignment.IsChecked.Value;
+            //Options.StrandSpecific = ckbStrandSpecific.IsChecked.Value;
+            //Options.InferStrandSpecificity = ckbInferStrandedness.IsChecked.Value;
+            //Options.SkipVariantAnalysis = CkbSkipVariantAnalysis.IsChecked.Value;
+            //Options.DoTranscriptIsoformAnalysis = CkbDoTranscriptIsoformAnalysis.IsChecked.Value;
+            //Options.DoFusionAnalysis = CkbDoGeneFusionAnalysis.IsChecked.Value;
+            //Options.VariantCallingWorkers = int.Parse(TxtVariantCallingWorkerNum.Text);
+            //Options.ProteinFastaPath = txtProteinFasta.Text;
             DialogResult = true;
         }
 
-        private void Window_Drop(object sender, DragEventArgs e)
-        {
-            string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
-            if (files != null)
-            {
-                foreach (var draggedFilePath in files)
-                {
-                    if (Directory.Exists(draggedFilePath))
-                    {
-                        foreach (string file in Directory.EnumerateFiles(draggedFilePath, "*.*", SearchOption.AllDirectories))
-                        {
-                            AddAFile(file);
-                        }
-                    }
-                    else
-                    {
-                        AddAFile(draggedFilePath);
-                    }
-                }
-            }
-        }
+        //private void Window_Drop(object sender, DragEventArgs e)
+        //{
+        //    string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
+        //    if (files != null)
+        //    {
+        //        foreach (var draggedFilePath in files)
+        //        {
+        //            if (Directory.Exists(draggedFilePath))
+        //            {
+        //                foreach (string file in Directory.EnumerateFiles(draggedFilePath, "*.*", SearchOption.AllDirectories))
+        //                {
+        //                    AddAFile(file);
+        //                }
+        //            }
+        //            else
+        //            {
+        //                AddAFile(draggedFilePath);
+        //            }
+        //        }
+        //    }
+        // }
 
-        private void AddAFile(string filepath)
-        {
-            var theExtension = filepath.EndsWith("gz") ?
-                Path.GetExtension(Path.GetFileNameWithoutExtension(filepath)).ToLowerInvariant() :
-                Path.GetExtension(filepath).ToLowerInvariant();
+        //private void AddAFile(string filepath)
+        //{
+        //    var theExtension = filepath.EndsWith("gz") ?
+        //        Path.GetExtension(Path.GetFileNameWithoutExtension(filepath)).ToLowerInvariant() :
+        //        Path.GetExtension(filepath).ToLowerInvariant();
 
-            if (theExtension == ".fa")
-                txtGenomeFasta.Text = filepath;
-            else if (theExtension == ".xml")
-                txtUniProtProteinXml.Text = filepath;
-            else if (theExtension == ".gtf" || theExtension.Contains("gff"))
-                txtGeneModelGtfOrGff.Text = filepath;
-            else if (theExtension == ".vcf")
-                txtDbsnpVcfReference.Text = filepath;
-            else
-                return;
-        }
+        //    if (theExtension == ".fa")
+        //        txtGenomeFasta.Text = filepath;
+        //    else if (theExtension == ".xml")
+        //        txtUniProtProteinXml.Text = filepath;
+        //    else if (theExtension == ".gtf" || theExtension.Contains("gff"))
+        //        txtGeneModelGtfOrGff.Text = filepath;
+        //    else if (theExtension == ".vcf")
+        //        txtDbsnpVcfReference.Text = filepath;
+        //    else
+        //        return;
+        //}
 
         private void UpdateFieldsFromTask(Options options)
         {
             // Get information about the fastq and sra selections
             var rnaSeqFastqCollection = (ObservableCollection<RNASeqFastqDataGrid>)MainWindow.DataGridRnaSeqFastq.DataContext;
-            if (rnaSeqFastqCollection.Count != 0)
-            {
-                Options.Fastq1 = string.Join(",", rnaSeqFastqCollection.Where(p => p.MatePair == 1.ToString()).OrderBy(p => p.Experiment).Select(p => p.FilePath).ToArray());
-                Options.Fastq2 = string.Join(",", rnaSeqFastqCollection.Where(p => p.MatePair == 2.ToString()).OrderBy(p => p.Experiment).Select(p => p.FilePath).ToArray());
-            }
+            Options.Fastq1 = string.Join(",", rnaSeqFastqCollection.Where(p => p.MatePair == 1.ToString()).OrderBy(p => p.FileName).Select(p => p.FileName.Substring(0, p.FileName.Length - 2)).ToArray());
+            Options.Fastq2 = string.Join(",", rnaSeqFastqCollection.Where(p => p.MatePair == 2.ToString()).OrderBy(p => p.FileName).Select(p => p.FileName.Substring(0, p.FileName.Length - 2)).ToArray());
+
             Options.ExperimentType = CmbxExperimentType.SelectedItem.ToString();
             var sraCollection = (ObservableCollection<SRADataGrid>)MainWindow.LbxSRAs.ItemsSource;
             Options.SraAccession = string.Join(",", sraCollection.Select(p => p.Name).ToArray());
@@ -232,25 +232,25 @@ namespace SpritzGUI
                 }
             }
 
-            // default workflow settings
-            //txtSpritzDirecory.Text = options.SpritzDirectory;
             txtAnalysisDirectory.Text = AnalysisDirectory;
             txtThreads.Text = options.Threads.ToString();
-            txtGenomeDir.Text = TrimQuotesOrNull(options.GenomeStarIndexDirectory);
-            txtNewGeneModelGtfOrGff.Text = TrimQuotesOrNull(options.NewGeneModelGtfOrGff);
             txtEnsemblReference.Text = options.Reference ?? "GRCh38";
-            txtUniProtProteinXml.Text = TrimQuotesOrNull(options.UniProtXml);
-            ckbOverWriteStarAlignment.IsChecked = options.OverwriteStarAlignments;
-            ckbStrandSpecific.IsChecked = options.StrandSpecific;
-            ckbInferStrandedness.IsChecked = options.InferStrandSpecificity;
-            CkbSkipVariantAnalysis.IsChecked = options.Fastq1 == null && options.SraAccession == null || options.SkipVariantAnalysis;
-            CkbDoTranscriptIsoformAnalysis.IsChecked = options.DoTranscriptIsoformAnalysis;
-            CkbDoGeneFusionAnalysis.IsChecked = options.DoFusionAnalysis;
             TxtVariantCallingWorkerNum.Text = options.VariantCallingWorkers.ToString();
-            txtProteinFasta.Text = options.ProteinFastaPath;
-            UpdateReference();
-        }
 
+            //txtSpritzDirecory.Text = options.SpritzDirectory;
+            //txtGenomeDir.Text = TrimQuotesOrNull(options.GenomeStarIndexDirectory);
+            //txtNewGeneModelGtfOrGff.Text = TrimQuotesOrNull(options.NewGeneModelGtfOrGff);
+            //txtUniProtProteinXml.Text = TrimQuotesOrNull(options.UniProtXml);
+            //ckbOverWriteStarAlignment.IsChecked = options.OverwriteStarAlignments;
+            //ckbStrandSpecific.IsChecked = options.StrandSpecific;
+            //ckbInferStrandedness.IsChecked = options.InferStrandSpecificity;
+            //CkbSkipVariantAnalysis.IsChecked = options.Fastq1 == null && options.SraAccession == null || options.SkipVariantAnalysis;
+            //CkbDoTranscriptIsoformAnalysis.IsChecked = options.DoTranscriptIsoformAnalysis;
+            //CkbDoGeneFusionAnalysis.IsChecked = options.DoFusionAnalysis;
+            //txtProteinFasta.Text = options.ProteinFastaPath;
+            //UpdateReference();
+        }
+        
         private string TrimQuotesOrNull(string a)
         {
             return a == null ? a : a.Trim('"');
@@ -270,64 +270,64 @@ namespace SpritzGUI
             CmbxIndelFinding.Items.Add("None");
             CmbxIndelFinding.Items.Add("GATK");
             CmbxIndelFinding.Items.Add("Scalpel");
-            CmbxIndelFinding.SelectedIndex = 1;
+            CmbxIndelFinding.SelectedIndex = 1; // hard coded selection (for now)
 
             CmbxExperimentType.Items.Add(ExperimentType.RNASequencing.ToString());
             CmbxExperimentType.Items.Add(ExperimentType.WholeGenomeSequencing.ToString());
             CmbxExperimentType.Items.Add(ExperimentType.ExomeSequencing.ToString());
-            CmbxExperimentType.SelectedIndex = 0;
+            CmbxExperimentType.SelectedIndex = 0; // hard coded selection (for now)
         }
 
-        private void txtStarFusionReference_TextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
-        {
-            UpdateReference();
-        }
+        //private void txtStarFusionReference_TextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
+        //{
+        //    UpdateReference();
+        //}
 
-        private void UpdateReference()
-        {
-            // Does dbSNP vcf already exist?
-            var gatk = new GATKWrapper(1);
-            string ensemblVcfPath = gatk.DownloadEnsemblKnownVariantSites(EverythingRunnerEngine.SpritzDirectory, true, txtEnsemblReference.Text, true);
-            if (File.Exists(ensemblVcfPath))
-            {
-                txtDbsnpVcfReference.Text = ensemblVcfPath;
-            }
-            else
-            {
-                txtDbsnpVcfReference.Text = TrimQuotesOrNull(null);
-            }
+        //private void UpdateReference()
+        //{
+        //    // Does dbSNP vcf already exist?
+        //    var gatk = new GATKWrapper(1);
+        //    string ensemblVcfPath = gatk.DownloadEnsemblKnownVariantSites(EverythingRunnerEngine.SpritzDirectory, true, txtEnsemblReference.Text, true);
+        //    if (File.Exists(ensemblVcfPath))
+        //    {
+        //        txtDbsnpVcfReference.Text = ensemblVcfPath;
+        //    }
+        //    else
+        //    {
+        //        txtDbsnpVcfReference.Text = TrimQuotesOrNull(null);
+        //    }
 
-            // Does gene model already exist?
-            if (AnalysisDirectory != null && AnalysisDirectory != "" && !Directory.Exists(AnalysisDirectory))
-            {
-                MessageBox.Show("Analysis directory does not exist.", "Workflow", MessageBoxButton.OK);
-                return;
-            }
-            var ensembl = new EnsemblDownloadsWrapper();
-            ensembl.DownloadReferences(EverythingRunnerEngine.SpritzDirectory, EverythingRunnerEngine.SpritzDirectory, txtEnsemblReference.Text, true);
-            if (File.Exists(ensembl.Gff3GeneModelPath))
-            {
-                txtGeneModelGtfOrGff.Text = ensembl.Gff3GeneModelPath;
-            }
-            else if (File.Exists(ensembl.GtfGeneModelPath))
-            {
-                txtGeneModelGtfOrGff.Text = ensembl.GtfGeneModelPath;
-            }
-            else
-            {
-                txtGeneModelGtfOrGff.Text = TrimQuotesOrNull(null);
-            }
+        //    // Does gene model already exist?
+        //    if (AnalysisDirectory != null && AnalysisDirectory != "" && !Directory.Exists(AnalysisDirectory))
+        //    {
+        //        MessageBox.Show("Analysis directory does not exist.", "Workflow", MessageBoxButton.OK);
+        //        return;
+        //    }
+        //    var ensembl = new EnsemblDownloadsWrapper();
+        //    ensembl.DownloadReferences(EverythingRunnerEngine.SpritzDirectory, EverythingRunnerEngine.SpritzDirectory, txtEnsemblReference.Text, true);
+        //    if (File.Exists(ensembl.Gff3GeneModelPath))
+        //    {
+        //        txtGeneModelGtfOrGff.Text = ensembl.Gff3GeneModelPath;
+        //    }
+        //    else if (File.Exists(ensembl.GtfGeneModelPath))
+        //    {
+        //        txtGeneModelGtfOrGff.Text = ensembl.GtfGeneModelPath;
+        //    }
+        //    else
+        //    {
+        //        txtGeneModelGtfOrGff.Text = TrimQuotesOrNull(null);
+        //    }
 
-            // Does genome reference already exist?
-            if (File.Exists(ensembl.GenomeFastaPath))
-            {
-                txtGenomeFasta.Text = ensembl.GenomeFastaPath;
-            }
-            else
-            {
-                txtGenomeFasta.Text = TrimQuotesOrNull(null);
-            }
-        }
+        //    // Does genome reference already exist?
+        //    if (File.Exists(ensembl.GenomeFastaPath))
+        //    {
+        //        txtGenomeFasta.Text = ensembl.GenomeFastaPath;
+        //    }
+        //    else
+        //    {
+        //        txtGenomeFasta.Text = TrimQuotesOrNull(null);
+        //    }
+        //}
 
         private void ChooseWorkerPreset()
         {

--- a/GUI/packages.config
+++ b/GUI/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Nett" version="0.11.0" targetFramework="net471" />
+  <package id="YamlDotNet" version="6.0.0" targetFramework="net471" />
 </packages>


### PR DESCRIPTION
first version for the GUI with snakemake. features:
- user can input sra
- user can input fastq files
- can only execute one workflow task at a time, can be cleared/reset
- all other options are hardcoded n snakemake: `GATK` and `GRCh38`

some things to know for the user:
- if any, fastq files must be located in user defined analysis directory
- others folders generated by snakemake e.g.`data` and `SnpEff` are located in user's current directory (in Debug mode this would be `/Spritz/GUI/bin/Debug`)
- user must have Powershell and `docker` installed

some things to know for us:
- docker is currently pulling an image from `rinaibrhm/spritz` docker hub
- image has to be rebuilt and pushed to docker hub for any edits/changes to snakemake rules/scripts/etc

i didn't really touch all the code for the toolkit wrappers but i don't think we need it anymore.
anyway, i feel like this still needs testing on your end. :)  
