### PR TITLE
Improving download speed and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Software for RNA-Seq analysis on Windows, including creating sample-specific pro
 [![Docker Pulls](https://img.shields.io/docker/pulls/smithlab/spritz)](https://hub.docker.com/r/smithlab/spritz/tags?page=1&ordering=last_updated)
 [![Follow us on Twitter](https://img.shields.io/twitter/follow/smith_chem_wisc?label=Twitter&style=social)](https://twitter.com/smith_chem_wisc)
 
-Spritz uses snakemake and Docker to install and run commandline tools for Next-Generation Sequencing (NGS) analysis.
-
 Spritz can be downloaded [here](https://github.com/smith-chem-wisc/Spritz/releases).
+
+Spritz uses snakemake and Docker to install and run commandline tools for Next-Generation Sequencing (NGS) analysis. These tools include an [adapted version of SnpEff](https://github.com/smith-chem-wisc/SnpEff) to annotate sequence variations and create an annotated protein database in XML format. The combinatorics of producing full-length proteoforms from these annotations is written in [mzLib's VariantApplication class](https://github.com/smith-chem-wisc/mzLib/blob/master/Proteomics/Protein/VariantApplication.cs).
 
 ![image](https://user-images.githubusercontent.com/16342951/93618988-a3b5be00-f99d-11ea-8be4-063395e24ce1.png)
 

--- a/Spritz/Snakefile
+++ b/Spritz/Snakefile
@@ -29,6 +29,8 @@ rule setup:
         UNIPROTFASTA,
         UNIPROTFASTA,
         FA,
+        "ptmlist.txt",
+        "PSI-MOD.obo.xml",
         "SnpEff/snpEff.jar",
         [] if not check('sra') else expand(["{dir}/{sra}_1.fastq", "{dir}/{sra}_2.fastq"], dir=config['analysisDirectory'], sra=config['sra']),
         [] if not check('sra_se') else expand(["{dir}/{sra_se}.fastq"], dir=config['analysisDirectory'], sra_se=config['sra_se'])

--- a/Spritz/TransferUniProtModifications/TransferUniProtModifications/Properties/launchSettings.json
+++ b/Spritz/TransferUniProtModifications/TransferUniProtModifications/Properties/launchSettings.json
@@ -1,7 +1,8 @@
 {
   "profiles": {
     "TransferUniProtModifications": {
-      "commandName": "Project"
+      "commandName": "Project",
+      "commandLineArgs": "--setup"
     }
   }
 }

--- a/Spritz/TransferUniProtModifications/TransferUniProtModifications/TransferUniProtModifications.cs
+++ b/Spritz/TransferUniProtModifications/TransferUniProtModifications/TransferUniProtModifications.cs
@@ -34,10 +34,21 @@ namespace TransferUniProtModifications
                 .As('z', "spritz_mod_xml")
                 .WithDescription("Custom protein XML withmods file, e.g. from Spritz.");
 
+            p.Setup(arg => arg.Setup)
+                .As('s', "setup")
+                .WithDescription("Perform setup for machines without internet connection.");
+
             p.SetupHelp("h", "help")
                 .Callback(text => Console.WriteLine(text));
 
             var result = p.Parse(args);
+
+            if (p.Object.Setup)
+            {
+                Console.WriteLine("Downloading files for TransferUniProtModifications.");
+                var uniprotPtms = ProteinAnnotation.GetUniProtMods(Environment.CurrentDirectory);
+                return;
+            }
 
             Console.WriteLine($"Analyzing UniProt database {p.Object.UniProtXml} and {p.Object.SpritzXml ?? p.Object.SpritzModXml ?? p.Object.FusionCodingEffects}");
 
@@ -199,6 +210,7 @@ namespace TransferUniProtModifications
             public string ReferenceGeneModel { get; set; }
             public string UniProtXml { get; set; }
             public string FusionCodingEffects { get; set; }
+            public bool Setup { get; set; }
         }
     }
 }

--- a/Spritz/config.yaml
+++ b/Spritz/config.yaml
@@ -1,6 +1,6 @@
-sra: [SRR629563] #  paired-end SRAs, comma separated, can leave empty, e.g. SRR629563
+sra: [] #  paired-end SRAs, comma separated, can leave empty, e.g. SRR629563
 fq: [] # paired-end fastq prefixes, comma separated, can leave empty, e.g. TestPairedEnd
-sra_se: [SRR8070095] # single-end SRAs, comma separated, can leave empty, e.g. SRR8070095
+sra_se: [] # single-end SRAs, comma separated, can leave empty, e.g. SRR8070095
 fq_se: [] # single-end fastq prefixes, comma separated, can leave empty, e.g. TestSingleEnd
 analysisDirectory: [AnalysisFolder] # for paths to drive e.g. /mnt/c/AnalysisFolder
 species: "Homo_sapiens"

--- a/Spritz/environment.yaml
+++ b/Spritz/environment.yaml
@@ -19,6 +19,7 @@ dependencies:
   - bcbio-gff
   - pandas
   - unzip
+  - gzip
   - wget
   - curl
   - dotnet-sdk =3.1.403

--- a/Spritz/rules/align.smk
+++ b/Spritz/rules/align.smk
@@ -113,7 +113,7 @@ if check('sra_se'):
         benchmark: "{dir}/{sra_se}.benchmark"
         log: "{dir}/{sra_se}.log"
         shell:
-            "fastq-dump -I --outdir {wildcards.dir} --split-files {input} &&
+            "fastq-dump -I --outdir {wildcards.dir} --split-files {input} && "
             "mv {wildcards.dir}/{wildcards.sra_se}_1.fastq {output} 2> {log}"
 
     rule fastp_sra_se:

--- a/Spritz/rules/proteogenomics.smk
+++ b/Spritz/rules/proteogenomics.smk
@@ -16,6 +16,11 @@ rule build_transfer_mods:
         "dotnet restore && "
         "dotnet build -c Release TransferUniProtModifications.sln) &> {log}"
 
+rule setup_transfer_mods:
+    input: TRANSFER_MOD_DLL
+    output: "ptmlist.txt", "PSI-MOD.obo.xml"
+    shell: "dotnet {input} --setup"
+
 rule transfer_modifications_variant:
     input:
         transfermods=TRANSFER_MOD_DLL,

--- a/Spritz/rules/proteogenomics.smk
+++ b/Spritz/rules/proteogenomics.smk
@@ -3,6 +3,7 @@ rule download_protein_xml:
         xml=UNIPROTXML,
         fasta=UNIPROTFASTA,
     log: f"{UNIPROTXML}.log"
+    benchmark: f"{UNIPROTXML}.benchmark"
     shell:
         "(python scripts/get_proteome.py && "
         "python scripts/download_uniprot.py xml | gzip -c > {output.xml} && " #fixme
@@ -11,6 +12,7 @@ rule download_protein_xml:
 rule build_transfer_mods:
     output: TRANSFER_MOD_DLL
     log: "data/TransferUniProtModifications.build.log"
+    benchmark: "data/TransferUniProtModifications.build.benchmark"
     shell:
         "(cd TransferUniProtModifications && "
         "dotnet restore && "
@@ -18,8 +20,12 @@ rule build_transfer_mods:
 
 rule setup_transfer_mods:
     input: TRANSFER_MOD_DLL
-    output: "ptmlist.txt", "PSI-MOD.obo.xml"
-    shell: "dotnet {input} --setup"
+    output:
+        "ptmlist.txt",
+        "PSI-MOD.obo.xml"
+    log: "data/setup_transfer_mods.log"
+    benchmark: "data/setup_transfer_mods.benchmark"
+    shell: "dotnet {input} --setup &> {log}"
 
 rule transfer_modifications_variant:
     input:
@@ -32,6 +38,7 @@ rule transfer_modifications_variant:
         protxmlwithmods=temp("{dir}/variants/combined.spritz.snpeff.protein.withmods.xml"),
         protxmlwithmodsgz="{dir}/variants/combined.spritz.snpeff.protein.withmods.xml.gz",
     log: "{dir}/variants/combined.spritz.snpeff.protein.withmods.log"
+    benchmark: "{dir}/variants/combined.spritz.snpeff.protein.withmods.benchmark"
     shell:
         "(dotnet {input.transfermods} -x {input.unixml} -y {input.protxml} && "
         "gzip -k {input.protxml} {output.protxmlwithmods}) &> {log}"


### PR DESCRIPTION
This PR improves the download speed of FASTQs from GEO SRA using `aspera` to perform the download, rather than `fasterq-dump`.

This also improves the setup for offline usage by downloading the ptmlist and PSI-MOD.