### PR TITLE
Unbreak the container build: conda-forge-first channels, drop defaults, pin base image

### DIFF
--- a/Spritz/Dockerfile
+++ b/Spritz/Dockerfile
@@ -1,4 +1,7 @@
-FROM mambaorg/micromamba
+# Pinned deliberately. This was previously untagged, so the image - and with it the micromamba and
+# solver versions - drifted on every rebuild. That is how the build came to fail with no change to
+# this repository. Bump this tag intentionally rather than inheriting a new base silently.
+FROM mambaorg/micromamba:2.9.0-ubuntu24.04
 LABEL maintainer="Anthony Cesnik <cesnik@wisc.edu>"
 
 # Set up micromamba and base env

--- a/Spritz/workflow/envs/align.yaml
+++ b/Spritz/workflow/envs/align.yaml
@@ -1,8 +1,7 @@
 # align.yaml: partial environment for alignment
 channels:
-  - bioconda
   - conda-forge
-  - defaults
+  - bioconda
 dependencies:
   - python =3.8
   - hisat2 =2.2.1

--- a/Spritz/workflow/envs/downloads.yaml
+++ b/Spritz/workflow/envs/downloads.yaml
@@ -1,8 +1,7 @@
 # downloads.yaml: partial environment for downloads
 channels:
-  - bioconda
   - conda-forge
-  - defaults
+  - bioconda
 dependencies:
   - python =3.8
   - numpy =1.19.4

--- a/Spritz/workflow/envs/isoforms.yaml
+++ b/Spritz/workflow/envs/isoforms.yaml
@@ -1,8 +1,7 @@
 # isoforms.yaml: partial environment for isoform reconstruction
 channels:
-  - bioconda
   - conda-forge
-  - defaults
+  - bioconda
 dependencies:
   - python =3.8
   - samtools =1.11

--- a/Spritz/workflow/envs/proteogenomics.yaml
+++ b/Spritz/workflow/envs/proteogenomics.yaml
@@ -1,8 +1,7 @@
 # proteogenomics.yaml: partial environment for proteogenomic database construction
 channels:
-  - bioconda
   - conda-forge
-  - defaults
+  - bioconda
 dependencies:
   - java-jdk =8.0 # snpeff
   - dotnet-runtime =6.0 # transfermods

--- a/Spritz/workflow/envs/quant.yaml
+++ b/Spritz/workflow/envs/quant.yaml
@@ -1,8 +1,7 @@
 # quant.yaml: partial environment for quantification with stringtie2
 channels:
-  - bioconda
   - conda-forge
-  - defaults
+  - bioconda
 dependencies:
   - python =3.8
   - numpy =1.19.4

--- a/Spritz/workflow/envs/spritzbase.yaml
+++ b/Spritz/workflow/envs/spritzbase.yaml
@@ -1,8 +1,7 @@
 # base_spritz.yaml: base environment for spritz
 channels:
-  - bioconda
   - conda-forge
-  - defaults
+  - bioconda
 dependencies:
   - snakemake-minimal =5.27.4
   - mamba

--- a/Spritz/workflow/envs/sra.yaml
+++ b/Spritz/workflow/envs/sra.yaml
@@ -1,7 +1,13 @@
 # sra.yaml: partial environment for SRA downloads
+#
+# NOTE: this is the one env that deliberately keeps bioconda ahead of conda-forge. Every other env
+# was switched to the conda-forge-first convention, but sra-tools =2.10.1 is a 2020 bioconda build
+# that needs an older zlib than conda-forge supplies; with conda-forge at higher priority under
+# strict channel priority the solve fails on a zlib version conflict. Verified: bioconda-first
+# solves, conda-forge-first does not. Bumping sra-tools (bioconda now has 3.4.1) would let this
+# follow the convention too, but 3.x changed fasterq-dump behaviour, so that is a separate change.
 channels:
   - bioconda
   - conda-forge
-  - defaults
 dependencies:
   - sra-tools =2.10.1

--- a/Spritz/workflow/envs/variants.yaml
+++ b/Spritz/workflow/envs/variants.yaml
@@ -1,8 +1,7 @@
 # variants.yaml: partial environment for variant calling
 channels:
-  - bioconda
   - conda-forge
-  - defaults
+  - bioconda
 dependencies:
   - java-jdk =8.0.92
   - gatk4 =4.2.0.0


### PR DESCRIPTION
🤖 The Docker image is currently unbuildable, so no Spritz release or fix can ship. This restores it.

## Symptom

`dockerbuild` fails while solving `spritzbase.yaml`:

```
error libmamba Could not solve for environment specs
  snakemake-minimal =5.27.4 is not installable because it requires
    ratelimiter, which does not exist (perhaps a missing channel).
```

`master` has not changed since 2024-06, so this is external drift, not a regression here. The published `smithlab/spritz:0.3.13` image still works, so **users are unaffected — but nothing can be rebuilt.**

Worth noting how long this went unseen. CI last passed **2025-11-19**, then had **no runs at all** until **2026-08-04** — GitHub disables `schedule:` crons in inactive repositories — and has failed daily since. The break landed inside that blind spot. (Hardening that signal is follow-up work, not in this PR.)

## The error message is misleading

`ratelimiter` has **not** been removed. It is on conda-forge as noarch `pyhd8ed1ab_1003`; it is **bioconda** that has none. The real mechanism is channel priority interacting with channel order. Verified three ways with `linux-64` solves:

| Channel order | Priority | Result |
|---|---|---|
| bioconda first | flexible (conda default) | ✅ solves — `ratelimiter` from conda-forge |
| bioconda first | **strict (micromamba default)** | ❌ fails |
| **conda-forge first** | strict | ✅ solves |

So these envs only ever worked by relying on a tool default. Putting conda-forge ahead of bioconda is also the documented bioconda convention, which these files had backwards.

## Changes

- **conda-forge before bioconda** in 7 env files.
- **Drop the `defaults` channel** from all 8 envs that listed it. Nothing here needs it, and Anaconda's ToS change makes it prompt or fail in automated solves — the failing build log contains a libmamba ToS warning.
- **Pin the base image.** `FROM mambaorg/micromamba` was untagged, which is what let micromamba and its solver defaults drift silently on every rebuild. Now `2.9.0-ubuntu24.04`. Bumping it should be a deliberate act.

## One exception, worth your attention

**`sra.yaml` deliberately keeps bioconda first.** `sra-tools =2.10.1` is a 2020 bioconda build that needs an older zlib than conda-forge supplies; under conda-forge-first with strict priority it fails on a zlib version conflict. Verified both ways. It still drops `defaults`, and carries a comment explaining why it differs.

This is the argument for checking every env rather than just the one the Dockerfile uses: `sra.yaml` is created by snakemake at pipeline runtime, so a blanket reorder would have shipped a **runtime break in SRA downloads while the image build went green**. Bumping `sra-tools` (bioconda has 3.4.1) would let it follow the convention, but 3.x changed `fasterq-dump` behaviour, so that belongs in its own PR.

## Verification

All **10** env files solve under strict channel priority for `linux-64`, checked with cross-platform `conda create --dry-run` plus `CONDA_OVERRIDE_GLIBC`:

```
PASS align.yaml     PASS isoforms.yaml        PASS quant.yaml       PASS sra.yaml
PASS default.yaml   PASS proteogenomics.yaml  PASS spritzbase.yaml  PASS variants.yaml
PASS dotnet_building.yaml                     PASS downloads.yaml
10/10
```

I did not build the image locally — that is left to CI, which is both the faithful environment and the one that has been failing. **The signal to watch is `dockerbuild` going green, including its containerized yeast smoke run** (`-r="release-96,saccharomyces_cerevisiae,…" -s=SRR13737862`), which also exercises `sra.yaml` and so covers the exception above.

## Not addressed here

Deliberately out of scope, and each worth its own PR: `snakemake-minimal =5.27.4` (2020), `python =3.8` and `numpy =1.19.4` (both EOL), .NET 6 (EOL 2024-11), outdated GitHub Actions, and the hardcoded `bin/x64/Release/net6.0` path that issue #240 tripped over.