### PR TITLE
Bump outdated GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 6.0.x
 
@@ -29,7 +29,7 @@ jobs:
       run: dotnet test --no-build --configuration Release --verbosity normal Spritz/Spritz.sln
 
     - name: Setup msbuild
-      uses: microsoft/setup-msbuild@v1.1
+      uses: microsoft/setup-msbuild@v3
 
     - name: Build Installer
       run: msbuild Spritz/SpritzInstaller/SpritzInstaller.wixproj /p:Configuration=Release
@@ -38,9 +38,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 6.0.x
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 6.0.x
 
@@ -37,7 +37,7 @@ jobs:
           dotnet test --configuration Release /p:Platform=x64 /p:Version=${version} --no-build Spritz/Spritz.sln
 
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v3
 
       - name: Build Installer
         run: |
@@ -45,7 +45,7 @@ jobs:
           msbuild Spritz/SpritzInstaller/SpritzInstaller.wixproj  /p:Configuration=Release /p:Version=${version}
 
       - name: Create archive
-        uses: thedoctor0/zip-release@0.7.1
+        uses: thedoctor0/zip-release@0.7.6
         with:
           type: 'zip'
           filename: 'SpritzCMD.zip'
@@ -53,14 +53,14 @@ jobs:
           directory: ./
 
       - name: Upload SpritzCMD
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@v2.11.5
         with:
           repo_token: ${{ secrets.UPLOAD_TOKEN }}
           file: SpritzCMD.zip
           tag: ${{ github.ref }}
 
       - name: Upload Installer
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@v2.11.5
         with:
           repo_token: ${{ secrets.UPLOAD_TOKEN }}
           file: Spritz/SpritzInstaller/bin/Release/Spritz.msi
@@ -71,9 +71,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 6.0.x
 


### PR DESCRIPTION
🤖 Housekeeping. Every workflow run currently emits:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/checkout@v3, actions/setup-dotnet@v3
```

## Changes

13 references across `build.yml` and `release.yml`:

| Action | From | To | Refs |
|---|---|---|---|
| `actions/checkout` | v3 | **v7** | 4 |
| `actions/setup-dotnet` | v3 | **v6** | 4 |
| `microsoft/setup-msbuild` | v1.1 | **v3** | 2 |
| `thedoctor0/zip-release` | 0.7.1 | **0.7.6** | 1 |
| `svenstaro/upload-release-action` | v2 | **v2.11.5** | 2 |

The two third-party release actions were floating on a mutable major tag or an old patch; both are now pinned to a specific release, for the same reason the container base image is being pinned in #244.

**No inputs changed.** The only inputs used anywhere are `dotnet-version` for setup-dotnet and the release-action parameters, none of which were removed across these majors. `dotnet-version` is deliberately left at `6.0.x` — moving off .NET 6, which reached end of support in 2024-11, is separate work.

## One thing to watch in CI

`setup-dotnet@v6` still has to acquire the **EOL** .NET 6 SDK. That should work, since EOL SDKs remain on the Microsoft release feed, but this PR is the cheapest place to find out. If it fails, that's an argument for doing the .NET 8 upgrade first — not a reason to stay on Node-20 actions.

## Relationship to #244

Independent — that PR touches the Dockerfile and `workflow/envs/*.yaml`, this one touches only `.github/workflows/`. No overlap, either order is fine.

Note that `dockerbuild` may still be red here for the reason #244 fixes (the `spritzbase.yaml` solve). If so, the meaningful signal on this PR is the `builds` job plus the absence of Node deprecation warnings; `dockerbuild` should be re-checked once #244 lands.