### PR TITLE
Decouple the workflow from .NET build output layout

### DIFF
--- a/Spritz/workflow/rules/common.smk
+++ b/Spritz/workflow/rules/common.smk
@@ -21,7 +21,19 @@ REF_FOLDER = f"../resources/ensembl/{SPECIES}.{GENEMODEL_VERSION}Rsem/"
 UNIPROTXML=f"../resources/uniprot/{config['species']}.protein.xml.gz" #"../resources/Homo_sapiens_202022.xml.gz"
 UNIPROTFASTA=f"../resources/uniprot/{config['species']}.protein.fasta" #"../resources/Homo_sapiens_202022.xml.gz"
 PREBUILT_SPRITZ_MODS = "prebuilt_spritz_mods" in config and config["prebuilt_spritz_mods"]
-TRANSFER_MOD_DLL="../SpritzModifications.dll" if PREBUILT_SPRITZ_MODS else "../SpritzModifications/bin/x64/Release/net6.0/SpritzModifications.dll"
+# Build output goes to a directory this workflow chooses, rather than to the SDK's default
+# bin/<Platform>/<Configuration>/<TargetFramework>/ layout. Naming that default here meant the
+# workflow silently depended on the platform, the configuration and the target framework all
+# staying put, and it broke when they did not (issue #240).
+#
+# Defined once, in two forms, because build_transfer_mods runs `dotnet build -o` from inside the
+# project directory while the rest of the workflow refers to the assembly from the workflow
+# directory. The rule passes SPRITZ_MODS_OUT_SUBDIR to -o via params, so the path the SDK writes to
+# and the path declared as the rule's output cannot fall out of step.
+SPRITZ_MODS_PROJECT_DIR = "../SpritzModifications"
+SPRITZ_MODS_OUT_SUBDIR = "bin/spritz"
+SPRITZ_MODS_OUT_DIR = f"{SPRITZ_MODS_PROJECT_DIR}/{SPRITZ_MODS_OUT_SUBDIR}"
+TRANSFER_MOD_DLL="../SpritzModifications.dll" if PREBUILT_SPRITZ_MODS else f"{SPRITZ_MODS_OUT_DIR}/SpritzModifications.dll"
 
 def all_output(wildcards):
     '''Gets the final output files depending on the configuration'''

--- a/Spritz/workflow/rules/proteogenomics.smk
+++ b/Spritz/workflow/rules/proteogenomics.smk
@@ -15,13 +15,16 @@ if not PREBUILT_SPRITZ_MODS:
     rule build_transfer_mods:
         '''Build the spritz modification C# project'''
         output: TRANSFER_MOD_DLL
+        params: outdir=SPRITZ_MODS_OUT_SUBDIR
         log: "../resources/SpritzModifications.build.log"
         benchmark: "../resources/SpritzModifications.build.benchmark"
         conda: "../envs/dotnet_building.yaml"
         shell:
+            # -o comes from the same variable that builds the declared output path above, so where
+            # the SDK writes the assembly and where the workflow looks for it cannot fall out of step.
             "(cd ../SpritzModifications && "
             "dotnet restore && "
-            "dotnet build /p:Platform=x64 -c Release SpritzModifications.csproj) &> {log}"
+            "dotnet build /p:Platform=x64 -c Release -o {params.outdir} SpritzModifications.csproj) &> {log}"
 
 rule setup_transfer_mods:
     '''Download the ptmlists to the resources directory'''


### PR DESCRIPTION
🤖 Prerequisite for the .NET 8 and arm64 work. **Please note this does _not_ fix #240** — see the bottom.

## The coupling

`common.smk` named the SDK's default output layout directly:

```python
TRANSFER_MOD_DLL = "../SpritzModifications/bin/x64/Release/net6.0/SpritzModifications.dll"
```

That string is the declared `output:` of `build_transfer_mods` and the declared `input:` of five downstream rules. So the workflow silently depended on the **platform**, the **configuration** and the **target framework** all staying exactly as written. Change any one and snakemake looks for an assembly the SDK no longer writes there — which is why this blocks both the .NET 8 upgrade and removing the hardcoded x64.

## The change

The workflow now chooses the output directory and tells the SDK to use it, via `dotnet build -o`:

```python
SPRITZ_MODS_PROJECT_DIR = "../SpritzModifications"
SPRITZ_MODS_OUT_SUBDIR  = "bin/spritz"
SPRITZ_MODS_OUT_DIR     = f"{SPRITZ_MODS_PROJECT_DIR}/{SPRITZ_MODS_OUT_SUBDIR}"
```

The rule passes `SPRITZ_MODS_OUT_SUBDIR` to `-o` through `params`, so the path the SDK writes to and the path snakemake declares come from one variable and cannot drift. (My first attempt spelled `bin/spritz` in both files with different relative bases — which would have reintroduced exactly the class of bug being removed. It now appears once in the tree.)

`bin/` is gitignored, so the fixed subdirectory is safe. The `prebuilt_spritz_mods` branch — what the container uses — is untouched.

## Verification

Done locally, because **CI cannot cover this** (see below):

- `dotnet build /p:Platform=x64 -c Release -o bin/spritz` puts `SpritzModifications.dll` exactly where `common.smk` now declares it, along with `runtimeconfig.json` and its 32 dependencies, so `dotnet <dll>` still works.
- The same build **with no `/p:Platform`**, and **with `-c Debug`**, lands in the same place. That is the property that makes the .NET 8 and arm64 changes safe.
- `snakemake --dry-run` (5.27.4, the pinned version) resolves the DAG with `prebuilt_spritz_mods: False`, and `--forcerun build_transfer_mods` shows the declared output and the `-o` argument agreeing:

```
output: ../SpritzModifications/bin/spritz/SpritzModifications.dll
shell:  (cd ../SpritzModifications && dotnet restore && \
         dotnet build /p:Platform=x64 -c Release -o bin/spritz SpritzModifications.csproj)
```

**CI coverage gap worth knowing:** the container sets `prebuilt_spritz_mods`, so `build_transfer_mods` does not exist in the Docker path and the smoke run will not exercise this rule at all. That asymmetry is why locally-building users are the ones who meet problems here, and why I verified with a real dry-run rather than leaning on CI.

`/p:Platform=x64` is deliberately left in place — removing it is the arm64 change, and it is now decoupled from the paths, so that can land independently.

## On #240

The hardcoded path appears in #240's error output, and I initially took that as its cause. It isn't. The error is `setup_transfer_mods` failing *after* the DLL was found — snakemake verifies inputs exist before running a rule, and `SpritzModifications --setup` then exited non-zero. `--setup` downloads `ptmlist.txt` and `PSI-MOD.obo.xml`, so #240 looks like a download failure in the same family as #225/#233. The reporter attached a log zip that should identify which download. Leaving it open.