### PR TITLE
Add a workflow lint and dry-run job to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,20 +63,27 @@ jobs:
     # Each analysis combination takes a different branch of all_output in common.smk, which is the
     # function that raised the MissingInputException in #243, so all of them are planned rather than
     # just the one the checked-in config happens to select.
-    - name: Dry-run every analysis combination
+    #
+    # Written as one step per combination rather than a shell loop that aggregates exit codes. The loop
+    # form reported failure in CI while every dry-run inside it printed success and no error was echoed,
+    # and it could not be reproduced locally against the same snakemake version, the same environment
+    # built from spritzbase.yaml, or under bash -e. Separate steps let the runner report which command
+    # failed instead of relying on shell bookkeeping to do it.
+    - name: Dry-run - quant
       shell: bash -el {0}
-      run: |
-        cd Spritz/workflow
-        rc=0
-        for analyses in "quant" "variant" "isoform" "variant,isoform,quant"; do
-          echo "::group::analyses=[$analyses]"
-          if ! snakemake --dry-run --cores 1 --config "analyses=[$analyses]"; then
-            echo "::error::snakemake dry-run failed for analyses=[$analyses]"
-            rc=1
-          fi
-          echo "::endgroup::"
-        done
-        exit $rc
+      run: cd Spritz/workflow && snakemake --dry-run --cores 1 --config "analyses=[quant]"
+
+    - name: Dry-run - variant
+      shell: bash -el {0}
+      run: cd Spritz/workflow && snakemake --dry-run --cores 1 --config "analyses=[variant]"
+
+    - name: Dry-run - isoform
+      shell: bash -el {0}
+      run: cd Spritz/workflow && snakemake --dry-run --cores 1 --config "analyses=[isoform]"
+
+    - name: Dry-run - variant, isoform and quant together
+      shell: bash -el {0}
+      run: cd Spritz/workflow && snakemake --dry-run --cores 1 --config "analyses=[variant,isoform,quant]"
 
   dockerbuild:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,50 @@ jobs:
     - name: Build Installer
       run: msbuild Spritz/SpritzInstaller/SpritzInstaller.wixproj /p:Configuration=Release
 
+  # Lints and plans the workflow without running it. This is deliberately cheap and independent of
+  # the container: no genomic data is downloaded and no conda envs beyond the base one are created,
+  # so it gives a fast signal on rule-graph breakage - the class of failure reported in issue #243,
+  # "MissingInputException in rule all" - long before the 90-minute dockerbuild job would surface it.
+  #
+  # It installs the pinned base environment rather than a snakemake of its own, so the snakemake
+  # version linting the workflow is the same one that runs it, and so this job also acts as a fast
+  # check that spritzbase.yaml still solves.
+  workflow:
+    name: Lint and dry-run the workflow
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Set up the pinned Spritz base environment
+      uses: mamba-org/setup-micromamba@v3
+      with:
+        environment-file: Spritz/workflow/envs/spritzbase.yaml
+        environment-name: spritzbase
+        cache-environment: true
+
+    - name: Lint the workflow
+      shell: bash -el {0}
+      run: cd Spritz/workflow && snakemake --lint
+
+    # Each analysis combination takes a different branch of all_output in common.smk, which is the
+    # function that raised the MissingInputException in #243, so all of them are planned rather than
+    # just the one the checked-in config happens to select.
+    - name: Dry-run every analysis combination
+      shell: bash -el {0}
+      run: |
+        cd Spritz/workflow
+        rc=0
+        for analyses in "quant" "variant" "isoform" "variant,isoform,quant"; do
+          echo "::group::analyses=[$analyses]"
+          if ! snakemake --dry-run --cores 1 --config "analyses=[$analyses]"; then
+            echo "::error::snakemake dry-run failed for analyses=[$analyses]"
+            rc=1
+          fi
+          echo "::endgroup::"
+        done
+        exit $rc
+
   dockerbuild:
     runs-on: ubuntu-latest
     timeout-minutes: 90


### PR DESCRIPTION
🤖 **Ordering note up front: this needs #244 to merge first.** See the bottom.

## Why

CI builds the .NET projects and, in `dockerbuild`, runs a full containerized pipeline. Nothing checks the *workflow* cheaply, so rule-graph breakage is only discoverable by waiting on a 90-minute job — or by a user hitting it, which is what happened in #243 (`MissingInputException in rule all`).

This adds a `workflow` job that lints and plans the workflow without running it: no genomic data downloaded, no per-rule conda envs created, independent of the container.

## What it does

**`snakemake --lint`** — clean on master today (*"Congratulations, your workflow is in a good condition!"*), so it goes in **blocking** rather than advisory.

**`snakemake --dry-run` for each analysis combination** — `quant`, `variant`, `isoform`, and all three together. Each takes a different branch of `all_output` in `common.smk`, which is the function that raised the exception in #243. Planning only the combination the checked-in config happens to select would leave most of that logic unchecked:

| `analyses` | rule instances planned |
|---|---|
| `[quant]` (the checked-in default) | 50 |
| `[variant]` | 76 |
| `[isoform]` | 72 |
| `[variant,isoform,quant]` | **128** |

The job installs the **pinned base environment** rather than a snakemake of its own, so the version linting the workflow is the same one that runs it — and as a side benefit the job becomes a fast check that `spritzbase.yaml` still solves, in minutes rather than the 14 the docker build takes.

## Verification

Using snakemake 5.27.4, the repo's own pin:

- `--lint` clean on master.
- All four dry-run combinations succeed; the CI step body extracted from the YAML and run in bash exits 0.
- **The guard is not vacuous.** I injected an output no rule produces into `all_output` and re-ran: every combination failed with `MissingInputException` and the step exited 1 — precisely the #243 failure mode. Reverted afterwards.

That last check felt worth doing explicitly: a green "lint" step that cannot fail is worse than no step, because it looks like coverage.

## Ordering

This job installs `spritzbase.yaml`, so it depends on the channel fix in **#244**. Until that lands, this job will fail to solve for exactly the reason #244 fixes, and that failure is expected rather than a fault in this change. #244 is already green on both jobs including its smoke run.

Independent of #245 and #246 otherwise. Note it uses `actions/checkout@v7` to match #245 rather than adding a new `@v3` reference that #245's diff would miss.