### PR TITLE
Make the three C# tests honest about what they test and what they need

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,14 +25,41 @@ jobs:
     - name: Build .NET
       run: dotnet build --no-restore --configuration Release /p:Platform=x64 Spritz/Spritz.sln
 
+    # Excludes tests that reach third-party services, so a UniProt or GitHub API outage cannot redden a
+    # pull request that did not break anything. Those tests still run, in the non-blocking job below.
     - name: Test .NET
-      run: dotnet test --no-build --configuration Release --verbosity normal Spritz/Spritz.sln
+      run: dotnet test --no-build --configuration Release --verbosity normal --filter "Category!=ExternalService" Spritz/Spritz.sln
 
     - name: Setup msbuild
       uses: microsoft/setup-msbuild@v3
 
     - name: Build Installer
       run: msbuild Spritz/SpritzInstaller/SpritzInstaller.wixproj /p:Configuration=Release
+
+  # Runs the tests that depend on third-party services: the GitHub releases API, and the UniProt ptmlist
+  # and PSI-MOD downloads that mzLib performs when those files are absent. Intentionally NOT a required
+  # check, so an upstream outage never blocks a PR, while a genuine break is still visible here.
+  # Do NOT add this job to branch-protection required checks.
+  external-service-tests:
+    name: External-service tests (non-blocking)
+    runs-on: windows-latest
+    timeout-minutes: 20
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v7
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: 6.0.x
+
+    - name: Restore dependencies
+      run: dotnet restore Spritz/Spritz.sln
+
+    - name: Build .NET
+      run: dotnet build --no-restore --configuration Release /p:Platform=x64 Spritz/Spritz.sln
+
+    - name: Test .NET (external services)
+      run: dotnet test --no-build --configuration Release --verbosity normal --filter "Category=ExternalService" Spritz/Spritz.sln
 
   dockerbuild:
     runs-on: ubuntu-latest

--- a/Spritz/SpritzTest/SpritzModificationsTests.cs
+++ b/Spritz/SpritzTest/SpritzModificationsTests.cs
@@ -1,16 +1,31 @@
 using NUnit.Framework;
 using SpritzModifications;
-using System;
 
 namespace SpritzTest
 {
     public class SpritzModificationsTests
     {
+        /// <summary>
+        /// Checks that the UniProt ptmlist parses against PSI-MOD into a non-empty modification set, which is
+        /// the input to every modification-transfer step in the pipeline.
+        ///
+        /// Categorised as an external-service test because it downloads. Neither ptmlist.txt nor
+        /// PSI-MOD.obo.xml is checked into this repository, and mzLib fetches whatever is missing -
+        /// Loaders.LoadPsiMod calls UpdatePsiMod, Loaders.LoadUniprot calls UpdateUniprot - so on a clean
+        /// checkout this always goes to the network. The "PSI-MOD database did not exist, writing to disk"
+        /// and "Uniprot database did not exist, writing to disk" lines in the test log are that download.
+        /// That dependency was previously invisible from the test, which meant an upstream outage looked
+        /// like a Spritz regression (compare issues #225 and #233).
+        /// </summary>
         [Test]
-        public void Test1()
+        [Category("ExternalService")]
+        public void GetUniProtMods_ParsesModificationsFromDownloadedPtmList()
         {
-            var mods = ProteinAnnotation.GetUniProtMods(Environment.CurrentDirectory);
-            Assert.Greater(mods.Count, 0);
+            var mods = ProteinAnnotation.GetUniProtMods(TestContext.CurrentContext.TestDirectory);
+
+            Assert.That(mods, Is.Not.Empty,
+                "no UniProt modifications were parsed from ptmlist.txt; check the download succeeded and the "
+                + "ptmlist format has not changed");
         }
     }
 }

--- a/Spritz/SpritzTest/SpritzVersionTests.cs
+++ b/Spritz/SpritzTest/SpritzVersionTests.cs
@@ -1,6 +1,5 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using SpritzBackend;
-using System;
 using System.IO;
 using System.Linq;
 
@@ -8,27 +7,90 @@ namespace SpritzTest
 {
     public class SpritzVersionTests
     {
+        /// <summary>
+        /// Guards against publishing a release newer than the version compiled into the code, i.e. against
+        /// forgetting to bump RunnerEngine.CurrentVersion.
+        ///
+        /// Queries the GitHub releases API, so it is categorised as an external-service test. It cannot pass
+        /// offline, and the unauthenticated GitHub API is rate limited per IP - which CI runners share - so it
+        /// is flaky by nature. It is excluded from the required CI run and executed in a separate
+        /// non-blocking job instead.
+        /// </summary>
         [Test]
-        public void TestVersionHigher()
+        [Category("ExternalService")]
+        public void PublishedReleaseIsNotNewerThanCompiledVersion()
         {
             SpritzVersion version = new();
             version.GetVersionNumbersFromWeb();
-            bool inReleaseOrlowerVersion =
-                version.NewestKnownVersion == RunnerEngine.CurrentVersion && version.NewestKnownVersionWithMsi == null
-                || SpritzVersion.IsVersionLower(version.NewestKnownVersionWithMsi);
-            Assert.IsTrue(inReleaseOrlowerVersion);
+
+            // Distinguish "the API told us nothing" from "the versions disagree". Without this, an API
+            // failure is reported as a version mismatch, which sends the reader to the wrong place.
+            Assert.That(version.NewestKnownVersion, Is.Not.Null.And.Not.Empty,
+                "the GitHub releases API returned no tag_name, so this is an external-service failure rather than a version mismatch");
+
+            // SpritzVersion.IsVersionLower(null) throws NullReferenceException rather than returning a
+            // value: GetVersionNumber catches FormatException but not a null input. The no-installer case is
+            // therefore handled here rather than being passed through it.
+            if (version.NewestKnownVersionWithMsi is null)
+            {
+                Assert.That(version.NewestKnownVersion, Is.EqualTo(RunnerEngine.CurrentVersion),
+                    $"newest published release is {version.NewestKnownVersion} and none carries an installer, "
+                    + $"but the code reports {RunnerEngine.CurrentVersion}");
+                return;
+            }
+
+            Assert.That(SpritzVersion.IsVersionLower(version.NewestKnownVersionWithMsi), Is.True,
+                $"newest published release with an installer is {version.NewestKnownVersionWithMsi}, which is newer "
+                + $"than the compiled version {RunnerEngine.CurrentVersion}; bump RunnerEngine.CurrentVersion");
         }
 
+        /// <summary>
+        /// The installer's Product/@Version and RunnerEngine.CurrentVersion must agree, otherwise a release
+        /// ships an installer labelled with a different version than the application reports. Runs offline.
+        /// </summary>
         [Test]
-        public void TestVersionMatchInstaller()
+        public void InstallerVersionMatchesCompiledVersion()
         {
-            var path = Path.Combine(Environment.CurrentDirectory, @"../../../../../SpritzInstaller/Product.wxs");
-            Assert.IsTrue(File.Exists(path));
-            var productFile = File.ReadLines(path).ToList();
-            string[] linesplit = productFile.First(x => x.Trim().StartsWith("<Product")).Split(' ');
-            var version = linesplit.First(x => x.StartsWith("Version")).Split("=")[1].Trim('"');
-            bool versionMatchesInstaller = version == RunnerEngine.CurrentVersion;
-            Assert.IsTrue(versionMatchesInstaller);
+            FileInfo productWxs = FindProductWxs();
+
+            string productLine = File.ReadLines(productWxs.FullName)
+                .FirstOrDefault(line => line.TrimStart().StartsWith("<Product"));
+            Assert.That(productLine, Is.Not.Null,
+                $"no <Product ...> element found in {productWxs.FullName}");
+
+            string versionAttribute = productLine.Split(' ')
+                .FirstOrDefault(token => token.StartsWith("Version"));
+            Assert.That(versionAttribute, Is.Not.Null,
+                $"the <Product ...> element in {productWxs.FullName} has no Version attribute: {productLine.Trim()}");
+
+            string installerVersion = versionAttribute.Split('=')[1].Trim('"');
+            Assert.That(installerVersion, Is.EqualTo(RunnerEngine.CurrentVersion),
+                $"{productWxs.Name} declares Version={installerVersion} but RunnerEngine.CurrentVersion is "
+                + $"{RunnerEngine.CurrentVersion}; these must be bumped together");
+        }
+
+        /// <summary>
+        /// Locates SpritzInstaller/Product.wxs by walking up from the test assembly.
+        ///
+        /// This was previously a fixed "../../../../../" hop from Environment.CurrentDirectory, which encoded
+        /// the depth of the build output directory - bin/{Platform}/{Configuration}/{TargetFramework} - and so
+        /// would silently start looking in the wrong place as soon as the platform or framework segment
+        /// changed. Searching upward for a known marker does not care how deep the output happens to be.
+        /// </summary>
+        private static FileInfo FindProductWxs()
+        {
+            string startedAt = TestContext.CurrentContext.TestDirectory;
+            for (DirectoryInfo directory = new(startedAt); directory is not null; directory = directory.Parent)
+            {
+                FileInfo candidate = new(Path.Combine(directory.FullName, "SpritzInstaller", "Product.wxs"));
+                if (candidate.Exists)
+                {
+                    return candidate;
+                }
+            }
+
+            Assert.Fail($"could not find SpritzInstaller/Product.wxs in any ancestor of {startedAt}");
+            return null; // unreachable; keeps the compiler happy
         }
     }
 }


### PR DESCRIPTION
🤖 All three tests passed, which was the problem. Two silently depended on the network, and one depended on the depth of the build output directory.

## Undeclared network dependencies — two of three, not one

`TestVersionHigher` calls the GitHub releases API. That was at least visible in the code.

**`Test1` was not.** It calls `GetUniProtMods`, and mzLib's `Loaders` download whatever is missing — `LoadPsiMod` → `UpdatePsiMod`, `LoadUniprot` → `UpdateUniprot`. Neither `ptmlist.txt` nor `PSI-MOD.obo.xml` is checked in, so on a clean checkout it **always** fetches. Running the suite prints the proof:

```
PSI-MOD database did not exist, writing to disk
Uniprot database did not exist, writing to disk
```

So an upstream outage presented as a Spritz regression — compare #225 and #233. And notably, **#240 turns out to be a TLS failure on this exact code path** (`UntrustedRoot` at `Loaders.DownloadPsiMod`), so this dependency has already bitten a user.

Both are now `[Category("ExternalService")]`, matching the convention MetaMorpheus uses, and CI is split to match:

- the required run gains `--filter "Category!=ExternalService"`
- a new **non-blocking** `external-service-tests` job runs `Category=ExternalService`

That keeps the coverage while stopping a third-party outage from reddening an unrelated PR.

## A path that was about to break

`TestVersionMatchInstaller` reached five levels up from `Environment.CurrentDirectory` to find `SpritzInstaller/Product.wxs`. Five levels is `bin/{Platform}/{Configuration}/{TargetFramework}` plus the project directory — so **removing the `x64` segment, which is exactly what the arm64 work does, would have made it look outside the repository.** It now walks up from `TestContext.CurrentContext.TestDirectory` looking for the file, which doesn't care how deep the output is.

## Smaller things

- `Test1` renamed to say what it checks.
- `Assert.IsTrue` on opaque booleans replaced with `Assert.That` plus messages naming the actual versions, so a failure says *which number is wrong* instead of `Expected: True, But was: False`.
- Stopped routing the no-installer case through `SpritzVersion.IsVersionLower(null)`, which throws `NullReferenceException` — `GetVersionNumber` catches `FormatException` but not a null input. Left as a latent issue in production code rather than fixed here; worth a separate look, since the GUI update check can reach it.

## Verification

Ran the suite rather than reasoning about it:

| Check | Result |
|---|---|
| `Category!=ExternalService` | 1 test, 14 ms, **no download lines** — the required run is genuinely offline |
| `Category=ExternalService` | 2 tests pass |
| built without `/p:Platform=x64` → `bin/Release/net6.0` | installer test still finds `Product.wxs`; the old hardcoded hop would have resolved outside the repo |

## Honest note on coverage

The required run is now **one** test. That reflects reality rather than reducing it — the other two never belonged in a blocking run — but it does make the thin C# coverage plain. The real coverage gain is the 11 untested Python workflow scripts, which is separate work.