### PR TITLE
Name the CA bundle explicitly for the .NET download in setup_transfer_mods

### DIFF
--- a/Spritz/workflow/rules/common.smk
+++ b/Spritz/workflow/rules/common.smk
@@ -24,7 +24,7 @@ PREBUILT_SPRITZ_MODS = "prebuilt_spritz_mods" in config and config["prebuilt_spr
 # Build output goes to a directory this workflow chooses, rather than to the SDK's default
 # bin/<Platform>/<Configuration>/<TargetFramework>/ layout. Naming that default here meant the
 # workflow silently depended on the platform, the configuration and the target framework all
-# staying put, and it broke when they did not (issue #240).
+# staying put, and would break as soon as any of them changed.
 #
 # Defined once, in two forms, because build_transfer_mods runs `dotnet build -o` from inside the
 # project directory while the rest of the workflow refers to the assembly from the workflow
@@ -34,6 +34,32 @@ SPRITZ_MODS_PROJECT_DIR = "../SpritzModifications"
 SPRITZ_MODS_OUT_SUBDIR = "bin/spritz"
 SPRITZ_MODS_OUT_DIR = f"{SPRITZ_MODS_PROJECT_DIR}/{SPRITZ_MODS_OUT_SUBDIR}"
 TRANSFER_MOD_DLL="../SpritzModifications.dll" if PREBUILT_SPRITZ_MODS else f"{SPRITZ_MODS_OUT_DIR}/SpritzModifications.dll"
+
+# .NET on Linux delegates TLS validation to OpenSSL, which resolves its CA store from its own
+# compiled-in OPENSSLDIR and from SSL_CERT_FILE / SSL_CERT_DIR rather than from the active conda
+# environment. Which store gets consulted therefore depends on which libssl happens to be loaded,
+# and that varies between environments. Naming the bundle explicitly removes the ambiguity.
+#
+# Motivated by the report in issue #240, where the HTTPS download in setup_transfer_mods failed with
+#
+#   System.Security.Authentication.AuthenticationException: The remote certificate is invalid
+#   because of errors in the certificate chain: UntrustedRoot
+#     at UsefulProteomicsDatabases.Loaders.DownloadPsiMod
+#
+# while, in the same run on the same machine, git cloned over HTTPS from github.com and `dotnet
+# restore` reached nuget.org over TLS - both successfully, in other conda environments. So the server
+# certificate and the machine's trust generally were fine; only .NET inside this environment failed.
+# The precise mechanism was never established and the report has not recurred, so treat this as
+# removing a known source of variability rather than as a proven fix.
+#
+# Guarded on the file existing so that an environment already resolving trust correctly - notably the
+# container, which works today - behaves exactly as before. Written as an `if` rather than
+# `[ -f x ] && export ...` purely for legibility; both are safe under the bash strict mode snakemake
+# uses, since a failing test that is not the final command of an && list does not trip errexit.
+CONDA_CA_BUNDLE_EXPORT = (
+    'if [ -f "$CONDA_PREFIX/ssl/cacert.pem" ]; '
+    'then export SSL_CERT_FILE="$CONDA_PREFIX/ssl/cacert.pem"; fi; '
+)
 
 def all_output(wildcards):
     '''Gets the final output files depending on the configuration'''

--- a/Spritz/workflow/rules/proteogenomics.smk
+++ b/Spritz/workflow/rules/proteogenomics.smk
@@ -34,8 +34,16 @@ rule setup_transfer_mods:
         "../resources/PSI-MOD.obo.xml"
     log: "../resources/setup_transfer_mods.log"
     benchmark: "../resources/setup_transfer_mods.benchmark"
-    conda: "../envs/spritzbase.yaml"  # using this for docker to be able to find ca-certificates
-    shell: "cd ../resources/ && dotnet {input} --setup &> {log}"
+    conda: "../envs/spritzbase.yaml"  # this env requires ca-certificates, which the download below needs
+    # This is the only rule that actually downloads through .NET: every other rule invoking the
+    # assembly declares ptmlist.txt and PSI-MOD.obo.xml as inputs, so snakemake has already produced
+    # them and mzLib's Loaders take the no-download path. See CONDA_CA_BUNDLE_EXPORT in common.smk for
+    # why OpenSSL is pointed at the environment's CA bundle here (see issue #240).
+    #
+    # Passed through params rather than concatenated into the shell string: snakemake --lint rejects
+    # '+' in a shell directive, reading it as path composition.
+    params: ca_bundle_export=CONDA_CA_BUNDLE_EXPORT
+    shell: "{params.ca_bundle_export} cd ../resources/ && dotnet {input} --setup &> {log}"
 
 rule setup_ptmlist_links:
     '''Link the resources to the workflow directory temporarily'''


### PR DESCRIPTION
🤖 Relates to #240 — **deliberately not "fixes"**. The change is a reasonable remedy, but the mechanism behind that report was never established, so this should not close the issue.

## Correcting my earlier claim

An earlier version of this PR said the conda environment had no CA bundle. **The rest of the reporter's log does not support that**, and I should have read it before writing the fix.

In the same run, on the same machine, two things succeeded that dismantle the simple explanations:

| What | Where | Result |
|---|---|---|
| `git clone https://github.com/dpryan79/ChromosomeMappings.git` | `downloads.yaml` env | ✅ |
| `dotnet restore` → nuget.org over TLS, **from .NET** | `dotnet_building.yaml` env | ✅ |
| `SpritzModifications --setup` → github.com over TLS, from .NET | `spritzbase.yaml` env | ❌ `UntrustedRoot` |

`setup_transfer_mods` was the **only** failure in the run. And `DownloadPsiMod` fetches from `https://github.com/smith-chem-wisc/psi-mod-CV/...` — the same host git reached successfully.

So the server certificate was fine, the machine's trust was fine generally, and blanket TLS interception is ruled out (which was the alternative worth considering, since `UntrustedRoot` is its classic signature). What remains is that .NET failed inside *one* conda environment, for reasons the log doesn't pin down.

Also note `spritzbase.yaml` explicitly requires `ca-certificates`, while `dotnet_building.yaml` — where .NET's TLS worked — does not. That's the opposite of what "no CA bundle" predicts.

## What the change does

.NET on Linux delegates TLS validation to OpenSSL, which resolves its CA store from its own compiled-in `OPENSSLDIR` and from `SSL_CERT_FILE`/`SSL_CERT_DIR`, not from the active conda environment. Which store gets consulted therefore depends on which `libssl` happens to be loaded, and that varies between environments. This names the bundle explicitly — conda puts it at `$CONDA_PREFIX/ssl/cacert.pem` — removing the ambiguity.

Framed honestly: **removing a known source of variability, not a diagnosed fix.** The report hasn't recurred, so it isn't worth blocking on further diagnosis.

- Guarded on the file existing, so an environment already resolving trust correctly — notably the container, which works today — behaves exactly as before.
- Applied only to `setup_transfer_mods`, the one rule that actually downloads: every other rule invoking the assembly declares `ptmlist.txt` and `PSI-MOD.obo.xml` as inputs, so mzLib takes the no-download path.
- Passed through `params`, because `snakemake --lint` rejects `+` in a shell directive as path composition — caught by the lint job from #247.

## Verification

- Rendered command is as intended, with `params` substituted literally rather than shell-quoted and `$CONDA_PREFIX` surviving snakemake's formatting.
- `--lint` clean; all four analysis combinations still plan.
- The guard behaves in both directions under bash strict mode: bundle absent → unset and the shell continues; present → set.
- The bundle named holds 121 certificates.

**Not verified:** that .NET honours `SSL_CERT_FILE`. Documented OpenSSL behaviour, but .NET on macOS validates through Keychain, so it can't be exercised here.

## Also in this PR

Corrects a comment #246 left behind attributing the hardcoded build path to #240. That attribution was mine and it was wrong.