### PR TITLE
Add pytest coverage for the Python workflow scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,28 @@ jobs:
       shell: bash -el {0}
       run: cd Spritz/workflow && snakemake --dry-run --cores 1 --config "analyses=[variant,isoform,quant]"
 
+  # Unit tests for the Python scripts in workflow/scripts. These carry the pipeline's data
+  # transformations - chromosome renaming, karyotypic sorting, VCF and GFF3 filtering - and had no
+  # coverage at all, so a change in behaviour would only have surfaced as odd output much later.
+  # Fast and offline: no genomic data, no containers, no network.
+  script-tests:
+    name: Workflow script tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Set up the test environment
+      uses: mamba-org/setup-micromamba@v3
+      with:
+        environment-file: Spritz/workflow/envs/tests.yaml
+        environment-name: spritz-tests
+        cache-environment: true
+
+    - name: Run pytest
+      shell: bash -el {0}
+      run: cd Spritz/workflow/tests && python -m pytest -v
+
   dockerbuild:
     runs-on: ubuntu-latest
     timeout-minutes: 90

--- a/Spritz/workflow/envs/tests.yaml
+++ b/Spritz/workflow/envs/tests.yaml
@@ -1,0 +1,11 @@
+# tests.yaml: environment for the workflow script tests
+#
+# Python is pinned to the same version the pipeline environments use, so the scripts are exercised
+# on the interpreter they actually run on. When that pin moves, move this one with it.
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python =3.8
+  - pytest
+  - pyyaml

--- a/Spritz/workflow/tests/conftest.py
+++ b/Spritz/workflow/tests/conftest.py
@@ -1,0 +1,55 @@
+"""Shared fixtures for the workflow script tests.
+
+The scripts in workflow/scripts are not importable modules: each one does its work at import
+time, reading config/config.yaml and ../resources/... by relative path and communicating over
+stdin, stdout and sys.argv. So they are exercised here the way the workflow actually invokes
+them - as subprocesses, from a directory laid out the way they expect - rather than by
+importing them. That tests the real contract, and needs no changes to the scripts themselves.
+"""
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+
+@pytest.fixture
+def workflow_dir(tmp_path):
+    """A directory shaped like workflow/, with a sibling resources/ tree.
+
+    Several scripts read "config/config.yaml" and "../resources/..." relative to the working
+    directory, so the fixture reproduces that shape instead of patching the scripts.
+    """
+    resources = tmp_path / "resources"
+    (resources / "ChromosomeMappings").mkdir(parents=True)
+    (resources / "ensembl").mkdir(parents=True)
+
+    workflow = tmp_path / "workflow"
+    (workflow / "config").mkdir(parents=True)
+    (workflow / "config" / "config.yaml").write_text(
+        textwrap.dedent(
+            """\
+            species: "Homo_sapiens"
+            genome: "GRCh38"
+            release: "100"
+            organism: "human"
+            analyses: [quant]
+            analysis_directory: [../results]
+            """
+        )
+    )
+    return workflow
+
+
+def run_script(name, cwd, stdin="", args=()):
+    """Run a workflow script the way a rule would, returning the CompletedProcess."""
+    return subprocess.run(
+        [sys.executable, os.path.join(SCRIPTS_DIR, name), *args],
+        cwd=str(cwd),
+        input=stdin,
+        capture_output=True,
+        text=True,
+    )

--- a/Spritz/workflow/tests/test_clean_vcf.py
+++ b/Spritz/workflow/tests/test_clean_vcf.py
@@ -1,0 +1,54 @@
+"""Tests for scripts/clean_vcf.py, which filters a VCF stream on stdin.
+
+Pure stdin to stdout with no configuration or resource files, so it is the most directly
+testable script in the workflow.
+"""
+from conftest import run_script
+
+HEADER = "##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+
+
+def clean(stdin, cwd):
+    result = run_script("clean_vcf.py", cwd, stdin=stdin)
+    assert result.returncode == 0, f"clean_vcf.py failed: {result.stderr}"
+    return result.stdout
+
+
+def test_header_lines_pass_through_unchanged(workflow_dir):
+    assert clean(HEADER, workflow_dir) == HEADER
+
+
+def test_ordinary_variant_is_kept(workflow_dir):
+    row = "1\t100\trs1\tA\tG\t50\tPASS\tAC=1\n"
+    assert clean(HEADER + row, workflow_dir) == HEADER + row
+
+
+def test_row_with_an_empty_field_in_the_first_seven_is_dropped(workflow_dir):
+    # An empty ID column. The script rejects an empty value anywhere in columns 0-6.
+    bad = "1\t100\t\tA\tG\t50\tPASS\tAC=1\n"
+    good = "1\t200\trs2\tC\tT\t50\tPASS\tAC=1\n"
+    assert clean(HEADER + bad + good, workflow_dir) == HEADER + good
+
+
+def test_alt_allele_without_a_recognised_base_is_dropped(workflow_dir):
+    # ALT of "<DEL>" shares no character with {A,C,T,G}, so it is unparsable here.
+    symbolic = "1\t100\trs1\tA\t<DEL>\t50\tPASS\tSVTYPE=DEL\n"
+    kept = "1\t200\trs2\tA\tG\t50\tPASS\tAC=1\n"
+    assert clean(HEADER + symbolic + kept, workflow_dir) == HEADER + kept
+
+
+def test_alt_with_more_than_one_duplicate_allele_pattern_is_dropped(workflow_dir):
+    # The script drops rows whose ALT contains more than one "<letter>." pattern.
+    duplicated = "1\t100\trs1\tA\tG.,T.\t50\tPASS\tAC=1\n"
+    kept = "1\t200\trs2\tA\tG\t50\tPASS\tAC=1\n"
+    assert clean(HEADER + duplicated + kept, workflow_dir) == HEADER + kept
+
+
+def test_a_single_duplicate_allele_pattern_is_still_kept(workflow_dir):
+    # Boundary of the rule above: one occurrence is allowed, two are not.
+    single = "1\t100\trs1\tA\tG.\t50\tPASS\tAC=1\n"
+    assert clean(HEADER + single, workflow_dir) == HEADER + single
+
+
+def test_empty_input_produces_empty_output(workflow_dir):
+    assert clean("", workflow_dir) == ""

--- a/Spritz/workflow/tests/test_convert_ensembl2ucsc.py
+++ b/Spritz/workflow/tests/test_convert_ensembl2ucsc.py
@@ -1,0 +1,87 @@
+"""Tests for scripts/convert_ensembl2ucsc.py.
+
+Renames Ensembl-style chromosomes to UCSC style and sorts the records. Takes input and output
+paths as argv. Invoked by rule convert2ucsc.
+
+Note that convert2ucsc is currently unreachable: nothing consumes its output
+({dir}/isoforms/combined_ucsc.gtf), and it does not appear in the DAG for any analysis
+combination. These tests therefore pin the behaviour of a script that does not presently run, so
+that the traps in it are visible to whoever wires it back up.
+"""
+from conftest import run_script
+
+MAPPING = "1\tchr1\n2\tchr2\n10\tchr10\nX\tchrX\nY\tchrY\nMT\tchrM\n"
+
+
+def convert(workflow_dir, contents, mapping=MAPPING, mapping_genome="GRCh38"):
+    mapping_path = (
+        workflow_dir.parent / "resources" / "ChromosomeMappings" / f"{mapping_genome}_ensembl2UCSC.txt"
+    )
+    mapping_path.write_text(mapping)
+
+    src = workflow_dir / "in.gtf"
+    src.write_text(contents)
+    dst = workflow_dir / "out.gtf"
+
+    result = run_script("convert_ensembl2ucsc.py", workflow_dir, args=[str(src), str(dst)])
+    return result, dst
+
+
+def test_ensembl_names_are_renamed_to_ucsc(workflow_dir):
+    result, dst = convert(workflow_dir, "1\tsource\texon\t1\t2\t.\t+\t.\tgene_id \"g\"\n")
+    assert result.returncode == 0, result.stderr
+    assert dst.read_text().split("\t")[0] == "chr1"
+
+
+def test_mitochondrion_is_renamed_from_MT_to_chrM(workflow_dir):
+    result, dst = convert(workflow_dir, "MT\tsource\texon\t1\t2\t.\t+\t.\tgene_id \"g\"\n")
+    assert result.returncode == 0, result.stderr
+    assert dst.read_text().split("\t")[0] == "chrM"
+
+
+def test_records_are_emitted_in_karyotypic_order(workflow_dir):
+    contents = "".join(
+        f"{chrom}\tsource\texon\t1\t2\t.\t+\t.\tgene_id \"g\"\n" for chrom in ["X", "10", "2", "MT", "1"]
+    )
+    result, dst = convert(workflow_dir, contents)
+    assert result.returncode == 0, result.stderr
+    chroms = [line.split("\t")[0] for line in dst.read_text().splitlines()]
+    assert chroms == ["chr1", "chr2", "chr10", "chrX", "chrM"]
+
+
+def test_rows_with_an_empty_field_in_the_first_seven_are_dropped(workflow_dir):
+    contents = (
+        "1\tsource\texon\t1\t2\t.\t\t.\tgene_id \"bad\"\n"
+        "2\tsource\texon\t1\t2\t.\t+\t.\tgene_id \"good\"\n"
+    )
+    result, dst = convert(workflow_dir, contents)
+    assert result.returncode == 0, result.stderr
+    assert "bad" not in dst.read_text()
+    assert "good" in dst.read_text()
+
+
+def test_the_configured_genome_is_ignored_in_favour_of_a_hardcoded_GRCh38(workflow_dir):
+    """Pins a trap, and is the reason this file exists.
+
+    The script reads "../resources/ChromosomeMappings/GRCh38_ensembl2UCSC.txt" as a literal, so
+    the `genome` value in config/config.yaml has no effect. Its sibling
+    convert_ucsc2ensembl.py interpolates {version} from config, so the two disagree.
+
+    Consequence if convert2ucsc is ever wired back into the DAG: a non-GRCh38 run - yeast
+    R64-1-1, mouse GRCm39 - would silently use *human* chromosome mappings. Names that are not in
+    the human map fall through to `otherchr` and are written out unconverted, so the output would
+    look plausible while carrying the wrong chromosome naming for the configured genome.
+
+    This test asserts the current behaviour: a config naming R64-1-1 still reads the GRCh38 file,
+    and fails if only an R64-1-1 mapping is present.
+    """
+    config = workflow_dir / "config" / "config.yaml"
+    config.write_text(config.read_text().replace('genome: "GRCh38"', 'genome: "R64-1-1"'))
+
+    # Only a correctly-named-for-the-config mapping file exists. A script honouring config would
+    # find it; this one looks for GRCh38 and fails.
+    result, _ = convert(workflow_dir, "I\tsource\texon\t1\t2\t.\t+\t.\tgene_id \"g\"\n",
+                        mapping="I\tchrI\n", mapping_genome="R64-1-1")
+
+    assert result.returncode != 0, "expected failure: the script ignores config and wants GRCh38"
+    assert "GRCh38_ensembl2UCSC.txt" in result.stderr, result.stderr

--- a/Spritz/workflow/tests/test_convert_ucsc2ensembl.py
+++ b/Spritz/workflow/tests/test_convert_ucsc2ensembl.py
@@ -1,0 +1,85 @@
+"""Tests for scripts/convert_ucsc2ensembl.py.
+
+Renames UCSC-style chromosomes to Ensembl style and sorts the records karyotypically. Reads a
+mapping file and config/config.yaml by relative path, reads a VCF on stdin and writes to stdout.
+Invoked by rule download_dbsnp_vcf as:
+
+    wget -O - <dbsnp> | zcat - | python scripts/convert_ucsc2ensembl.py > {output}
+"""
+from conftest import run_script
+
+HEADER = "##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+
+MAPPING = "chr1\t1\nchr2\t2\nchr10\t10\nchrX\tX\nchrY\tY\nchrM\tMT\n"
+
+
+def write_mapping(workflow_dir, contents=MAPPING, genome="GRCh38"):
+    mapping = workflow_dir.parent / "resources" / "ChromosomeMappings" / f"{genome}_UCSC2ensembl.txt"
+    mapping.write_text(contents)
+    return mapping
+
+
+def convert(workflow_dir, stdin):
+    write_mapping(workflow_dir)
+    result = run_script("convert_ucsc2ensembl.py", workflow_dir, stdin=stdin)
+    assert result.returncode == 0, f"script failed: {result.stderr}"
+    return result.stdout
+
+
+def body(stdout):
+    """Records only, dropping the header lines."""
+    return [line for line in stdout.splitlines() if not line.startswith("#")]
+
+
+def test_header_lines_pass_through_first(workflow_dir):
+    out = convert(workflow_dir, HEADER + "chr1\t100\trs1\tA\tG\t.\t.\t.\n")
+    assert out.startswith(HEADER)
+
+
+def test_ucsc_names_are_renamed_to_ensembl(workflow_dir):
+    out = convert(workflow_dir, HEADER + "chr1\t100\trs1\tA\tG\t.\t.\t.\n")
+    assert body(out) == ["1\t100\trs1\tA\tG\t.\t.\t."]
+
+
+def test_mitochondrion_is_renamed_from_chrM_to_MT(workflow_dir):
+    out = convert(workflow_dir, HEADER + "chrM\t50\trsM\tA\tG\t.\t.\t.\n")
+    assert body(out)[0].split("\t")[0] == "MT"
+
+
+def test_records_are_emitted_in_karyotypic_order(workflow_dir):
+    # Deliberately supplied out of order, and including 10 so that plain lexicographic sorting
+    # would put it before 2.
+    stdin = HEADER + "".join(
+        f"{chrom}\t100\trs\tA\tG\t.\t.\t.\n" for chrom in ["chrX", "chr10", "chr2", "chrM", "chr1"]
+    )
+    out = convert(workflow_dir, stdin)
+    assert [line.split("\t")[0] for line in body(out)] == ["1", "2", "10", "X", "MT"]
+
+
+def test_unmapped_contigs_are_kept_after_the_named_chromosomes(workflow_dir):
+    stdin = HEADER + "chrUn_something\t1\trs\tA\tG\t.\t.\t.\nchr1\t100\trs\tA\tG\t.\t.\t.\n"
+    out = convert(workflow_dir, stdin)
+    chroms = [line.split("\t")[0] for line in body(out)]
+    assert chroms[0] == "1", "named chromosomes should come first"
+    assert "chrUn_something" in chroms, "an unmapped contig should be retained, not dropped"
+
+
+def test_script_truncates_the_rules_output_file(workflow_dir):
+    """Pins a hazard rather than endorsing it.
+
+    The script opens ../resources/ensembl/<species>.ensembl.vcf for writing and never writes
+    through that handle - every record goes to stdout instead. Rule download_dbsnp_vcf redirects
+    stdout to that very same path, so the script truncates the file its caller is writing.
+
+    It survives only because the open happens before any output is produced, so the redirect's
+    file offset is still 0. Move that open below the loop, or have a caller write earlier, and the
+    output would be destroyed. This test records the current behaviour so the coupling is visible;
+    the tidy fix is to drop the unused handle.
+    """
+    ensembl_vcf = workflow_dir.parent / "resources" / "ensembl" / "Homo_sapiens.ensembl.vcf"
+    ensembl_vcf.write_text("this content should survive a well-behaved script\n")
+
+    out = convert(workflow_dir, HEADER + "chr1\t100\trs1\tA\tG\t.\t.\t.\n")
+
+    assert body(out) == ["1\t100\trs1\tA\tG\t.\t.\t."], "records still go to stdout"
+    assert ensembl_vcf.read_text() == "", "the script truncated the file and wrote nothing to it"

--- a/Spritz/workflow/tests/test_simplify_gff3.py
+++ b/Spritz/workflow/tests/test_simplify_gff3.py
@@ -1,0 +1,64 @@
+"""Tests for scripts/simplify_gff3.py.
+
+Strips exon and UTR features from a GFF3, so that SnpEff builds a database from transcript-level
+records only. Takes the input path as argv[1] and writes to stdout. Invoked as:
+
+    python scripts/simplify_gff3.py {input} > {output}
+"""
+from conftest import run_script
+
+GFF3 = """\
+##gff-version 3
+##sequence-region 1 1 248956422
+1\tensembl\tgene\t100\t500\t.\t+\t.\tID=gene:G1
+1\tensembl\ttranscript\t100\t500\t.\t+\t.\tID=transcript:T1
+1\tensembl\texon\t100\t200\t.\t+\t.\tID=exon:E1
+1\tensembl\tCDS\t120\t200\t.\t+\t0\tID=CDS:C1
+1\tensembl\tfive_prime_UTR\t100\t119\t.\t+\t.\tID=utr:U1
+1\tensembl\tthree_prime_UTR\t450\t500\t.\t+\t.\tID=utr:U2
+"""
+
+
+def simplify(workflow_dir, contents=GFF3):
+    gff = workflow_dir / "in.gff3"
+    gff.write_text(contents)
+    result = run_script("simplify_gff3.py", workflow_dir, args=[str(gff)])
+    assert result.returncode == 0, f"script failed: {result.stderr}"
+    return result.stdout
+
+
+def feature_types(stdout):
+    return [line.split("\t")[2] for line in stdout.splitlines() if len(line.split("\t")) > 2]
+
+
+def test_exon_features_are_removed(workflow_dir):
+    assert "exon" not in feature_types(simplify(workflow_dir))
+
+
+def test_utr_features_are_removed(workflow_dir):
+    types = feature_types(simplify(workflow_dir))
+    assert not any(t.endswith("UTR") for t in types), types
+
+
+def test_gene_transcript_and_cds_are_kept(workflow_dir):
+    assert feature_types(simplify(workflow_dir)) == ["gene", "transcript", "CDS"]
+
+
+def test_comment_lines_are_dropped(workflow_dir):
+    """Pins current behaviour, which is worth a second look.
+
+    The guard is `emptyOrComment = len(linesplit) < 3 or line.startswith("#")`, and only lines
+    where that is false are written - so the "##gff-version 3" pragma is discarded along with the
+    rest. A GFF3 file is supposed to open with that pragma, and some parsers require it. This
+    records what the script does today rather than asserting that it is right.
+    """
+    out = simplify(workflow_dir)
+    assert "##gff-version" not in out
+    assert not any(line.startswith("#") for line in out.splitlines())
+
+
+def test_a_feature_whose_name_merely_contains_utr_is_kept(workflow_dir):
+    # The test is endswith("UTR"), so this is retained. Guards against a future change to a
+    # substring match, which would silently discard records like this one.
+    contents = GFF3 + "1\tensembl\tUTR_adjacent_region\t600\t700\t.\t+\t.\tID=x\n"
+    assert "UTR_adjacent_region" in feature_types(simplify(workflow_dir, contents))


### PR DESCRIPTION
🤖 The eleven scripts in `workflow/scripts` carry the pipeline's data transformations — chromosome renaming, karyotypic sorting, VCF and GFF3 filtering — and had **no tests at all**. 23 tests across four of them, plus a CI job. Fast and offline: no genomic data, no container, no network.

# ⚠️ Three findings, two on live paths

Writing the tests surfaced these. **Severity is verified, not guessed** — I checked DAG reachability for each rather than assuming, and one of my initial alarms turned out to be unreachable.

### 1. `convert_ucsc2ensembl.py` truncates the file its caller is writing — **LIVE**

Reached via `download_dbsnp_vcf`. The script opens `../resources/ensembl/<species>.ensembl.vcf` with mode `"w"` and **never writes through that handle** — every record goes to stdout. The rule redirects stdout to *that same path*:

```
wget -O - {dbsnp} | zcat - | python scripts/convert_ucsc2ensembl.py > {output}
```

It survives only because the `open` happens before any output is produced, so the redirect's file offset is still 0. **Move that open below the loop and the dbSNP VCF is silently emptied**, losing known-site annotation for every variant call downstream. The fix is to delete the unused handle; pinned by a test meanwhile.

### 2. `simplify_gff3.py` strips the GFF3 pragma, and its output feeds the SnpEff database — **LIVE**

Reached via `remove_exon_and_utr_information`, whose output flows through `copy_gff3_to_snpeff` into `SnpEff/data/.../genes.gff` — the annotation database used for **variant effect prediction**.

The guard treats "starts with `#`" the same as "too few columns" and drops both, so `##gff-version 3` never reaches the output. **Whether SnpEff tolerates its absence I did not verify** — that's the open question, and why this is flagged rather than fixed here. If it silently mis-parses, annotations could be affected.

### 3. `convert_ensembl2ucsc.py` ignores the configured genome — **not live**

It reads `"GRCh38_ensembl2UCSC.txt"` as a literal, while its sibling interpolates `{version}` from config. A yeast or mouse run would silently use **human** mappings, with unmapped names falling through unconverted — output that looks plausible but carries the wrong naming.

**Harmless today**, because `convert2ucsc` is unreachable: nothing consumes `combined_ucsc.gtf` and it appears in no DAG. So this is a trap for whoever wires it back up, not current corruption. I flagged it as active before checking; the DAG check corrected me. The rule also fails to declare the mapping file as an input, unlike its sibling.

---

## Approach

The scripts aren't importable modules — each does its work at import time, reading `config/config.yaml` and `../resources/...` by relative path and communicating over stdin/stdout/argv. So they're exercised **as subprocesses**, from a directory laid out the way they expect (`conftest.py` builds it).

That tests the contract the rules actually rely on, and needs no changes to the scripts. Deliberate ordering: cover the behaviour first, refactor into testable functions later *against* these tests.

## Coverage

**Covered:** `clean_vcf.py`, `simplify_gff3.py`, `convert_ucsc2ensembl.py`, `convert_ensembl2ucsc.py`.

**Not covered, and why:** `filter_fasta.py` and `karyotypic_order.py` need biopython and a genome FASTA; `prose.py`, `SummarizeQuantGtf.py`, `SummarizeQuantTab.py`, `get_proteome.py` and `download_uniprot.py` need larger fixtures or network. Worth a follow-up.

Several tests deliberately **pin current behaviour rather than assert correctness** — each says so in its docstring, so nobody mistakes a passing test for an endorsement.

## Verification

- 23 tests pass on **python 3.8**, the version the pipeline pins — `tests.yaml` matches that pin deliberately, and should move when #21 moves it.
- `tests.yaml` solves for `linux-64` under strict channel priority.
- `snakemake --lint` still clean with the new `tests/` directory present.