### PR TITLE
Move to .NET 10 LTS, and stop stamping x64 into the container payload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v6
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 10.0.x
 
     - name: Restore dependencies
       run: dotnet restore Spritz/Spritz.sln
@@ -93,7 +93,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v6
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 10.0.x
 
     - name: Restore dependencies
       run: dotnet restore Spritz/SpritzCMD/SpritzCMD.csproj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
       run: dotnet restore Spritz/SpritzCMD/SpritzCMD.csproj
 
     - name: Build SpritzCMD
-      run: dotnet build --no-restore /p:Platform=x64 --configuration Release Spritz/SpritzCMD/SpritzCMD.csproj
+      run: dotnet build --no-restore --configuration Release Spritz/SpritzCMD/SpritzCMD.csproj
 
     - name: Build docker image
       run: docker build -t spritz ./Spritz/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
       run: dotnet restore Spritz/SpritzCMD/SpritzCMD.csproj
 
     - name: Build SpritzCMD
-      run: dotnet build --no-restore /p:Platform=x64 --configuration Release Spritz/SpritzCMD/SpritzCMD.csproj
+      run: dotnet build --no-restore --configuration Release Spritz/SpritzCMD/SpritzCMD.csproj
 
     - name: Build docker image
       run: docker build -t spritz ./Spritz/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 10.0.x
 
       - name: Verify commit exists in release branch
         run: |
@@ -49,7 +49,7 @@ jobs:
         with:
           type: 'zip'
           filename: 'SpritzCMD.zip'
-          path: Spritz/SpritzCMD/bin/x64/Release/net6.0/
+          path: Spritz/SpritzCMD/bin/x64/Release/net10.0/
           directory: ./
 
       - name: Upload SpritzCMD
@@ -75,7 +75,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v6
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 10.0.x
 
     - name: Restore dependencies
       run: dotnet restore Spritz/SpritzCMD/SpritzCMD.csproj

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Spritz uses snakemake and Docker to install and run commandline tools for Next-G
 
 * Environment:
   * Windows 10 recommended
-  * [.NET Core 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-6.0.13-windows-x64-installer)
+  * [.NET Desktop Runtime 10.0](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) - the GUI is a WPF application, so the plain .NET Runtime is not sufficient
 * 24 GB RAM recommended
 * The installer ([Spritz.msi](https://github.com/smith-chem-wisc/Spritz/releases)) only works on Windows.
 

--- a/Spritz/Dockerfile
+++ b/Spritz/Dockerfile
@@ -10,6 +10,6 @@ RUN micromamba install -y -n base -f /tmp/spritzbase.yaml \
         && micromamba clean --all --yes
 
 # install prebuilt SpritzCMD
-COPY ./SpritzCMD/bin/x64/Release/net6.0/ /app/spritz/
+COPY ./SpritzCMD/bin/x64/Release/net10.0/ /app/spritz/
 WORKDIR /app/spritz/
 

--- a/Spritz/Dockerfile
+++ b/Spritz/Dockerfile
@@ -10,6 +10,6 @@ RUN micromamba install -y -n base -f /tmp/spritzbase.yaml \
         && micromamba clean --all --yes
 
 # install prebuilt SpritzCMD
-COPY ./SpritzCMD/bin/x64/Release/net10.0/ /app/spritz/
+COPY ./SpritzCMD/bin/Release/net10.0/ /app/spritz/
 WORKDIR /app/spritz/
 

--- a/Spritz/SpritzBackend/SpritzBackend.csproj
+++ b/Spritz/SpritzBackend/SpritzBackend.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Platforms>x64</Platforms>
   </PropertyGroup>
 

--- a/Spritz/SpritzBackend/SpritzBackend.csproj
+++ b/Spritz/SpritzBackend/SpritzBackend.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Platforms>x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Spritz/SpritzCMD/SpritzCMD.csproj
+++ b/Spritz/SpritzCMD/SpritzCMD.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
-    <Platforms>x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Spritz/SpritzCMD/SpritzCMD.csproj
+++ b/Spritz/SpritzCMD/SpritzCMD.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Platforms>x64</Platforms>
   </PropertyGroup>
 

--- a/Spritz/SpritzGUI/SpritzGUI.csproj
+++ b/Spritz/SpritzGUI/SpritzGUI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>Spritz.ico</ApplicationIcon>
     <SignAssembly>false</SignAssembly>

--- a/Spritz/SpritzModifications/SpritzModifications.csproj
+++ b/Spritz/SpritzModifications/SpritzModifications.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
-    <Platforms>x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Spritz/SpritzModifications/SpritzModifications.csproj
+++ b/Spritz/SpritzModifications/SpritzModifications.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Platforms>x64</Platforms>
   </PropertyGroup>
 

--- a/Spritz/SpritzTest/SpritzTest.csproj
+++ b/Spritz/SpritzTest/SpritzTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Spritz/workflow/envs/dotnet_building.yaml
+++ b/Spritz/workflow/envs/dotnet_building.yaml
@@ -2,4 +2,4 @@
 channels:
   - conda-forge
 dependencies:
-  - dotnet-sdk=6.0
+  - dotnet-sdk=10.0

--- a/Spritz/workflow/envs/proteogenomics.yaml
+++ b/Spritz/workflow/envs/proteogenomics.yaml
@@ -4,5 +4,5 @@ channels:
   - bioconda
 dependencies:
   - java-jdk =8.0 # snpeff
-  - dotnet-runtime =6.0 # transfermods
+  - dotnet-runtime =10.0 # transfermods
   - ca-certificates

--- a/Spritz/workflow/envs/spritzbase.yaml
+++ b/Spritz/workflow/envs/spritzbase.yaml
@@ -7,5 +7,5 @@ dependencies:
   - mamba
   - python=3.8
   - conda
-  - dotnet-runtime=6.0
+  - dotnet-runtime=10.0
   - ca-certificates

--- a/Spritz/workflow/rules/proteogenomics.smk
+++ b/Spritz/workflow/rules/proteogenomics.smk
@@ -24,7 +24,7 @@ if not PREBUILT_SPRITZ_MODS:
             # the SDK writes the assembly and where the workflow looks for it cannot fall out of step.
             "(cd ../SpritzModifications && "
             "dotnet restore && "
-            "dotnet build /p:Platform=x64 -c Release -o {params.outdir} SpritzModifications.csproj) &> {log}"
+            "dotnet build -c Release -o {params.outdir} SpritzModifications.csproj) &> {log}"
 
 rule setup_transfer_mods:
     '''Download the ptmlists to the resources directory'''


### PR DESCRIPTION
🤖 Two commits: the runtime upgrade, then the arm64 fix folded in at review request. Closes the work tracked as .NET 6 EOL and the hardcoded-x64 item.

## .NET 6 → .NET 10

.NET 6 left support on **2024-11-12**. Going to .NET 8 would have been churn onto a runtime whose own LTS window closes in **November 2026**, so this goes straight to .NET 10, supported into 2028.

Fourteen references across ten files: five csproj TFMs (including `net6.0-windows` for the WPF GUI), `dotnet-runtime` in `spritzbase.yaml` and `proteogenomics.yaml`, `dotnet-sdk` in `dotnet_building.yaml`, the Dockerfile COPY path, `dotnet-version` in both `build.yml` jobs and two places in `release.yml`, and the release artifact path — which named the TFM the same way the Dockerfile did.

conda-forge has `dotnet-runtime` and `dotnet-sdk` 10.x for every platform Spritz needs (linux-64, win-64, osx-64, osx-arm64, linux-aarch64), so the environments aren't a constraint.

**Verified** with SDK 10.0.302 on an x64 host, built and tested the way CI does (`Release`, `Platform=x64`): solution builds with no errors, all three tests pass.

## Stop stamping x64 into the container payload

Same shape as the recent mzLib and MetaMorpheus fixes. **Before this, `SpritzCMD.dll` could not start on an arm64 runtime at all.**

Scoped to what a Docker user actually runs:

- dropped `<Platforms>x64</Platforms>` from `SpritzBackend`, `SpritzCMD`, `SpritzModifications`
- both workflows build `SpritzCMD` at project level with no platform, so output is neutral and lands in `bin/Release`
- the Dockerfile copies from that path
- `build_transfer_mods` no longer passes `/p:Platform=x64`, so the in-container build is neutral too

**The solution file is deliberately untouched.** It offers only `x64` and `x86`, so building it as Any CPU would mean adding a solution platform — and as found in mzLib, MSBuild then *prefers* Any CPU as the default, silently changing what an unqualified build produces. Project-level builds already default to Any CPU and the container path already builds `SpritzCMD` directly, so nothing needed restructuring. `SpritzGUI` and `SpritzTest` keep x64: both are Windows-only in practice and feed the x64 installer.

**Verified:**

| Check | Result |
|---|---|
| Container assemblies | `PE32 ... Intel 80386` (MSIL), not `PE32+ x86-64` |
| Output path | `bin/Release/net10.0/`, matching the Dockerfile |
| `SpritzCMD.dll` on an **arm64** runtime | runs, same help output as x64 — previously couldn't load |
| Windows regression | solution still builds `Platform=x64`, all three tests pass |

## Necessary but not sufficient, exactly as in MetaMorpheus

The mzLib package ships x64-stamped assemblies, so `SpritzModifications` still fails on arm64:

```
Could not load file or assembly 'Proteomics, Version=1.0.540.0'
```

`Proteomics.dll` from the package is `PE32+ x86-64` and isn't ours to fix. Full arm64 needs an mzLib release built architecture-neutral — the packaging fix is merged upstream as smith-chem-wisc/mzLib#1127 but **not yet released** — and then a bump here from **1.0.540**, which is ten releases behind.

## One finding worth a follow-up

The newer SDK enables NuGet auditing by default, so the build now reports **`NU1902`: `OpenMcdf 2.2.1.3` has a known moderate severity vulnerability**, pulled in transitively by that pinned mzLib 1.0.540. It's a warning, not an error, and it predates this change — it becomes *visible* now because the tooling started looking. The mzLib bump above would likely clear it.

## Note on local verification

Two test failures I hit while verifying were **not** caused by this change, and are worth recording so nobody re-chases them: on an arm64 SDK, `Test1` fails on mzLib's x64 `Proteomics.dll` (the issue above), and `TestVersionMatchInstaller` fails when built without `Platform=x64` because its hardcoded `../../../../../` path assumes a five-deep output directory — the fragility #248 has since fixed. Both pass on an x64 host built as CI builds.