### PR TITLE
Trim the GUI runtime requirement to one line

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Spritz uses snakemake and Docker to install and run commandline tools for Next-G
 
 * Environment:
   * Windows 10 recommended
-  * [.NET Desktop Runtime 10.0](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) - the GUI is a WPF application, so the plain .NET Runtime is not sufficient
+  * .NET Desktop Runtime 10
 * 24 GB RAM recommended
 * The installer ([Spritz.msi](https://github.com/smith-chem-wisc/Spritz/releases)) only works on Windows.
 


### PR DESCRIPTION
Follow-up to #252, which updated this line to .NET 10 but left it wordy.

Keeps "Desktop" because it is load-bearing: `SpritzGUI.csproj` sets `UseWPF`, and WPF ships in the
Desktop Runtime rather than the base .NET Runtime, so a user who installs the plain runtime gets one
that cannot start the application. The installer does not bundle a runtime either - `Product.wxs`
installs assemblies only - so this line is the only thing telling a user what to install.

Drops the download link, which pointed at a specific patch release and went stale on every patch.