### PR TITLE
Move off end-of-life Python 3.8, and fix the quant matrix scripts

### DIFF
--- a/Spritz/SpritzBackend/RunnerEngine.cs
+++ b/Spritz/SpritzBackend/RunnerEngine.cs
@@ -72,7 +72,10 @@ namespace SpritzBackend
         public string GenerateSnakemakeCommand(SpritzOptions options, bool setup)
         {
             string cmd = "";
-            cmd += $"snakemake -j {options.Threads} --use-conda --conda-frontend mamba --configfile {Path.Combine(ConfigDirectory, "config.yaml")}";
+            // No --conda-frontend: snakemake 9 accepts the flag but prints "Ignoring the alternative
+            // conda frontend setting (mamba)" and uses conda, which now solves via libmamba anyway.
+            // Passing it only produced a warning on every run.
+            cmd += $"snakemake -j {options.Threads} --use-conda --configfile {Path.Combine(ConfigDirectory, "config.yaml")}";
             if (setup)
             {
                 cmd += " setup.txt";

--- a/Spritz/SpritzBackend/SpritzOptionStrings.cs
+++ b/Spritz/SpritzBackend/SpritzOptionStrings.cs
@@ -72,7 +72,7 @@ namespace SpritzBackend
             "Copy-paste a line from the file you get with the -x option that retrieves available references.";
 
         public static readonly string InfoSupp =
-            $"The Spritz commandline interface intended to be run within a conda environment containing the programs snakemake and mamba.{Environment.NewLine}" +
+            $"The Spritz commandline interface intended to be run within a conda environment containing the programs snakemake and conda.{Environment.NewLine}" +
             Environment.NewLine +
             $"Example workflow using this tool: {Environment.NewLine}" +
             $"1) Check out the available references with the -x command. Specify a target directory with -a.{Environment.NewLine}" +

--- a/Spritz/SpritzCMD/Spritz.cs
+++ b/Spritz/SpritzCMD/Spritz.cs
@@ -93,7 +93,7 @@ namespace SpritzCMD
                 .WithDescription(SpritzOptionStrings.ReferenceDesc);
 
             string helpoutro = "";
-            helpoutro += $"The Spritz commandline interface intended to be run within a conda environment containing the programs snakemake and mamba." + Environment.NewLine;
+            helpoutro += $"The Spritz commandline interface intended to be run within a conda environment containing the programs snakemake and conda." + Environment.NewLine;
             helpoutro += Environment.NewLine;
             helpoutro += $"Example workflow using this tool:" + Environment.NewLine;
             helpoutro += $"1) Check out the available references with the -x command. Specify a target directory with -a." + Environment.NewLine;

--- a/Spritz/workflow/envs/align.yaml
+++ b/Spritz/workflow/envs/align.yaml
@@ -5,7 +5,5 @@ channels:
 dependencies:
   - python =3.13
   - hisat2 =2.2.1
-  # samtools 1.11 pins zlib <1.3 and an old ncurses, which cannot coexist with any python newer
-  # than 3.10, so this pin had to move with the interpreter rather than by choice.
-  - samtools =1.24
+  - samtools =1.24 # 1.11 pins zlib <1.3 and an old ncurses; will not solve past python 3.10
   - fastp

--- a/Spritz/workflow/envs/align.yaml
+++ b/Spritz/workflow/envs/align.yaml
@@ -3,7 +3,9 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - python =3.8
+  - python =3.13
   - hisat2 =2.2.1
-  - samtools =1.11
+  # samtools 1.11 pins zlib <1.3 and an old ncurses, which cannot coexist with any python newer
+  # than 3.10, so this pin had to move with the interpreter rather than by choice.
+  - samtools =1.24
   - fastp

--- a/Spritz/workflow/envs/default.yaml
+++ b/Spritz/workflow/envs/default.yaml
@@ -2,5 +2,5 @@
 channels:
   - conda-forge
 dependencies:
-  - python =3.8
+  - python =3.13
   - pyyaml

--- a/Spritz/workflow/envs/downloads.yaml
+++ b/Spritz/workflow/envs/downloads.yaml
@@ -3,8 +3,11 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - python =3.8
-  - numpy =1.19.4
+  - python =3.13
+  # numpy was pinned to 1.19.4, which has no build for any python past 3.9, so the pin could not be
+  # carried forward. Left unpinned rather than re-pinned: nothing here depends on a numpy version,
+  # and biopython and pandas already constrain it to something they work with.
+  - numpy
   - requests
   - pyyaml
   - git

--- a/Spritz/workflow/envs/downloads.yaml
+++ b/Spritz/workflow/envs/downloads.yaml
@@ -4,10 +4,7 @@ channels:
   - bioconda
 dependencies:
   - python =3.13
-  # numpy was pinned to 1.19.4, which has no build for any python past 3.9, so the pin could not be
-  # carried forward. Left unpinned rather than re-pinned: nothing here depends on a numpy version,
-  # and biopython and pandas already constrain it to something they work with.
-  - numpy
+  - numpy # was =1.19.4, which has no build past python 3.9; nothing here needs a version
   - requests
   - pyyaml
   - git

--- a/Spritz/workflow/envs/isoforms.yaml
+++ b/Spritz/workflow/envs/isoforms.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python =3.13
   - samtools =1.24 # see align.yaml
-  - stringtie =2.1.7 # see quant.yaml
+  - stringtie
   - gzip # use conda's gzip, not the system's
   - picard # for ProteomeGenerator
   - transdecoder # for ProteomeGenerator

--- a/Spritz/workflow/envs/isoforms.yaml
+++ b/Spritz/workflow/envs/isoforms.yaml
@@ -4,9 +4,8 @@ channels:
   - bioconda
 dependencies:
   - python =3.13
-  # See align.yaml: samtools 1.11 cannot coexist with a supported python.
-  - samtools =1.24
-  - stringtie
+  - samtools =1.24 # see align.yaml
+  - stringtie =2.1.7 # see quant.yaml
   - gzip # use conda's gzip, not the system's
   - picard # for ProteomeGenerator
   - transdecoder # for ProteomeGenerator

--- a/Spritz/workflow/envs/isoforms.yaml
+++ b/Spritz/workflow/envs/isoforms.yaml
@@ -3,8 +3,9 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - python =3.8
-  - samtools =1.11
+  - python =3.13
+  # See align.yaml: samtools 1.11 cannot coexist with a supported python.
+  - samtools =1.24
   - stringtie
   - gzip # use conda's gzip, not the system's
   - picard # for ProteomeGenerator

--- a/Spritz/workflow/envs/quant.yaml
+++ b/Spritz/workflow/envs/quant.yaml
@@ -4,8 +4,7 @@ channels:
   - bioconda
 dependencies:
   - python =3.13
-  # See downloads.yaml for why the numpy pin is gone rather than raised.
-  - numpy
-  - stringtie
+  - numpy # see downloads.yaml
+  - stringtie =2.1.7 # the version that produced the U2OS results; unpinned now resolves 3.x
   - gzip # use conda's gzip, not the system's
   - pandas

--- a/Spritz/workflow/envs/quant.yaml
+++ b/Spritz/workflow/envs/quant.yaml
@@ -3,8 +3,9 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - python =3.8
-  - numpy =1.19.4
+  - python =3.13
+  # See downloads.yaml for why the numpy pin is gone rather than raised.
+  - numpy
   - stringtie
   - gzip # use conda's gzip, not the system's
   - pandas

--- a/Spritz/workflow/envs/quant.yaml
+++ b/Spritz/workflow/envs/quant.yaml
@@ -5,6 +5,6 @@ channels:
 dependencies:
   - python =3.13
   - numpy # see downloads.yaml
-  - stringtie =2.1.7 # the version that produced the U2OS results; unpinned now resolves 3.x
+  - stringtie
   - gzip # use conda's gzip, not the system's
   - pandas

--- a/Spritz/workflow/envs/spritzbase.yaml
+++ b/Spritz/workflow/envs/spritzbase.yaml
@@ -3,9 +3,7 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  # snakemake and python move together. snakemake 5.27.4 depends on ratelimiter, which caps python
-  # at 3.10, and every python that is still supported needs a snakemake that dropped that dependency.
-  - snakemake-minimal =9.25.1
+  - snakemake-minimal =9.25.1 # 5.27.4 needed ratelimiter, which caps python at 3.10
   - python =3.13
   - conda
   - dotnet-runtime=10.0

--- a/Spritz/workflow/envs/spritzbase.yaml
+++ b/Spritz/workflow/envs/spritzbase.yaml
@@ -3,9 +3,10 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - snakemake-minimal =5.27.4
-  - mamba
-  - python=3.8
+  # snakemake and python move together. snakemake 5.27.4 depends on ratelimiter, which caps python
+  # at 3.10, and every python that is still supported needs a snakemake that dropped that dependency.
+  - snakemake-minimal =9.25.1
+  - python =3.13
   - conda
   - dotnet-runtime=10.0
   - ca-certificates

--- a/Spritz/workflow/envs/tests.yaml
+++ b/Spritz/workflow/envs/tests.yaml
@@ -9,3 +9,5 @@ dependencies:
   - python =3.13
   - pytest
   - pyyaml
+  - numpy
+  - pandas

--- a/Spritz/workflow/envs/tests.yaml
+++ b/Spritz/workflow/envs/tests.yaml
@@ -6,6 +6,6 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - python =3.8
+  - python =3.13
   - pytest
   - pyyaml

--- a/Spritz/workflow/envs/tests.yaml
+++ b/Spritz/workflow/envs/tests.yaml
@@ -1,12 +1,9 @@
 # tests.yaml: environment for the workflow script tests
-#
-# Python is pinned to the same version the pipeline environments use, so the scripts are exercised
-# on the interpreter they actually run on. When that pin moves, move this one with it.
 channels:
   - conda-forge
   - bioconda
 dependencies:
-  - python =3.13
+  - python =3.13 # keep in step with the pipeline environments
   - pytest
   - pyyaml
   - numpy

--- a/Spritz/workflow/envs/variants.yaml
+++ b/Spritz/workflow/envs/variants.yaml
@@ -5,4 +5,4 @@ channels:
 dependencies:
   - java-jdk =8.0.92
   - gatk4 =4.2.0.0
-  - samtools =1.11
+  - samtools =1.24

--- a/Spritz/workflow/scripts/SummarizeQuantGtf.py
+++ b/Spritz/workflow/scripts/SummarizeQuantGtf.py
@@ -27,7 +27,8 @@ for file in files:
 tpms.insert(0, np.asarray(ids))
 
 print(f"Saving to {outtpms} ...")
-dataframe = np.row_stack(tpms)
+# NumPy 2.0 removed np.row_stack, which was an alias for np.vstack.
+dataframe = np.vstack(tpms)
 dataframe[1:,0] = [os.path.basename(file).split(".")[0] for file in files]
 pddf = pd.DataFrame(dataframe[1:,1:], index=dataframe[1:,0], columns=dataframe[0,1:]).sort_index()
 pddf.T.to_csv(outtpms)

--- a/Spritz/workflow/scripts/SummarizeQuantGtf.py
+++ b/Spritz/workflow/scripts/SummarizeQuantGtf.py
@@ -1,34 +1,71 @@
-import sys, os
-import numpy as np
+"""Combine StringTie transcript GTFs into one transcript-by-sample TPM matrix.
+
+Joins on transcript ID, for the same reason as SummarizeQuantTab.py: the previous implementation
+stacked values positionally and assumed every sample emitted its transcripts in the same order.
+"""
+import os
+import re
+import sys
+
 import pandas as pd
 
-outtpms = sys.argv[1]
-files = sys.argv[2:]
-ids = []
-tpms = []
-for file in files:
-    print(f"reading {os.path.basename(file)}")
-    currIds = []
-    currTpms = []
-    for line in open(file):
-        if line.startswith("#") : continue
-        lins = line.split("\t")
-        if lins[2] != "transcript": continue
-        info = dict(x.split(' ') for x in lins[8].split('; '))
-        transcriptId = info["transcript_id"].strip('"').strip(';')
-        covText = info["cov"].strip('"').strip(';')
-        fpkmText = info["FPKM"].strip('"').strip(';')
-        tpmText = info["TPM"].strip().strip(';').strip('"')
-        currIds.append(transcriptId)
-        currTpms.append(tpmText)
-    if len(ids) == 0: ids = np.asarray(currIds)
-    elif all(np.array(currIds) != ids): print("error with ids")
-    tpms.append(currTpms)
-tpms.insert(0, np.asarray(ids))
+# GTF attributes are `key "value"` pairs. Matching them rather than splitting on '; ' and ' '
+# tolerates values containing spaces, missing trailing semicolons and extra attributes - none of
+# which StringTie's -e output produces today, but a --merge GTF carrying gene_name would.
+ATTRIBUTE = re.compile(r'(\w+)\s+"([^"]*)"')
 
-print(f"Saving to {outtpms} ...")
-# NumPy 2.0 removed np.row_stack, which was an alias for np.vstack.
-dataframe = np.vstack(tpms)
-dataframe[1:,0] = [os.path.basename(file).split(".")[0] for file in files]
-pddf = pd.DataFrame(dataframe[1:,1:], index=dataframe[1:,0], columns=dataframe[0,1:]).sort_index()
-pddf.T.to_csv(outtpms)
+
+def sample_name(path):
+    """The sample label for a quant file, e.g. SRR13737862.sra.transcript.quant_ref.gtf -> SRR13737862."""
+    return os.path.basename(path).split(".")[0]
+
+
+def read_transcript_tpms(path):
+    """Reads one StringTie GTF as a transcript-indexed TPM series.
+
+    Only `transcript` features carry TPM; exon rows are skipped. Duplicated transcript IDs are
+    summed, matching SummarizeQuantTab.py, so a repeated ID cannot silently overwrite an earlier
+    value or break the join.
+    """
+    transcript_ids = []
+    tpms = []
+    with open(path) as handle:
+        for line in handle:
+            if line.startswith("#"):
+                continue
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) < 9 or fields[2] != "transcript":
+                continue
+            attributes = dict(ATTRIBUTE.findall(fields[8]))
+            if "transcript_id" not in attributes or "TPM" not in attributes:
+                continue
+            transcript_ids.append(attributes["transcript_id"])
+            tpms.append(float(attributes["TPM"]))
+
+    frame = pd.DataFrame({"transcript_id": transcript_ids, "TPM": tpms})
+    return frame.groupby("transcript_id")["TPM"].sum()
+
+
+def build_matrix(input_files):
+    """Transcripts down the rows, samples across the columns, aligned on transcript ID."""
+    tpms_by_sample = {sample_name(path): read_transcript_tpms(path) for path in input_files}
+    return pd.concat(tpms_by_sample, axis=1).sort_index().sort_index(axis=1)
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: SummarizeQuantGtf.py <output_file> <input_file_1> <input_file_2> ...")
+        sys.exit(1)
+
+    output_file = sys.argv[1]
+    input_files = sys.argv[2:]
+
+    for path in input_files:
+        print(f"reading {os.path.basename(path)}")
+
+    print(f"Saving to {output_file} ...")
+    build_matrix(input_files).to_csv(output_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/Spritz/workflow/scripts/SummarizeQuantGtf.py
+++ b/Spritz/workflow/scripts/SummarizeQuantGtf.py
@@ -30,17 +30,32 @@ def read_transcript_tpms(path):
     transcript_ids = []
     tpms = []
     with open(path) as handle:
-        for line in handle:
+        for line_number, line in enumerate(handle, start=1):
             if line.startswith("#"):
                 continue
             fields = line.rstrip("\n").split("\t")
             if len(fields) < 9 or fields[2] != "transcript":
                 continue
             attributes = dict(ATTRIBUTE.findall(fields[8]))
-            if "transcript_id" not in attributes or "TPM" not in attributes:
-                continue
+            # Raise rather than skip. A silent skip would turn a StringTie output change into an
+            # empty or partial matrix that no downstream step notices; the version is not pinned,
+            # so what produces these files can move under us.
+            missing = [name for name in ("transcript_id", "TPM") if name not in attributes]
+            if missing:
+                raise ValueError(
+                    f"{os.path.basename(path)} line {line_number}: transcript row has no "
+                    f"{' or '.join(missing)}. Attributes present: "
+                    f"{', '.join(sorted(attributes)) or 'none'}. "
+                    "If StringTie changed its attribute names, this script needs updating."
+                )
             transcript_ids.append(attributes["transcript_id"])
             tpms.append(float(attributes["TPM"]))
+
+    if not transcript_ids:
+        raise ValueError(
+            f"{os.path.basename(path)}: no 'transcript' features found. Either the file is empty "
+            "or StringTie no longer labels these rows 'transcript'."
+        )
 
     frame = pd.DataFrame({"transcript_id": transcript_ids, "TPM": tpms})
     return frame.groupby("transcript_id")["TPM"].sum()

--- a/Spritz/workflow/scripts/SummarizeQuantTab.py
+++ b/Spritz/workflow/scripts/SummarizeQuantTab.py
@@ -31,7 +31,8 @@ def main():
         tpms_list.append(currTpms)
 
     tpms_list.insert(0, ids_list)
-    dataframe = np.row_stack(tpms_list)
+    # NumPy 2.0 removed np.row_stack, which was an alias for np.vstack.
+    dataframe = np.vstack(tpms_list)
     dataframe[1:, 0] = [os.path.basename(file).split(".")[0] for file in input_files]
     
     # Create a DataFrame and save to CSV

--- a/Spritz/workflow/scripts/SummarizeQuantTab.py
+++ b/Spritz/workflow/scripts/SummarizeQuantTab.py
@@ -21,7 +21,15 @@ def read_gene_tpms(path):
     StringTie can report the same gene ID on more than one line - it does so in the U2OS data, for
     gene:ENSG00000242759 - so the duplicates are summed rather than left to collide in the join.
     """
-    table = pd.read_csv(path, sep="\t", usecols=["Gene ID", "TPM"])
+    try:
+        table = pd.read_csv(path, sep="\t", usecols=["Gene ID", "TPM"])
+    except ValueError as error:
+        # pandas already refuses to read missing columns; this only makes the reason obvious.
+        # StringTie's version is not pinned, so its column names can move under us.
+        raise ValueError(
+            f"{os.path.basename(path)}: expected StringTie -A columns 'Gene ID' and 'TPM'. "
+            "If StringTie changed its header, this script needs updating."
+        ) from error
     return table.groupby("Gene ID")["TPM"].sum()
 
 

--- a/Spritz/workflow/scripts/SummarizeQuantTab.py
+++ b/Spritz/workflow/scripts/SummarizeQuantTab.py
@@ -1,12 +1,40 @@
-import sys
+"""Combine StringTie gene abundance tables (-A output) into one gene-by-sample TPM matrix.
+
+Joins on gene ID. The previous implementation stacked the values positionally with numpy and
+assumed every sample listed its genes in the same order, which is not true of StringTie output:
+the same gene set comes back in a different order per sample. See the notes on each helper.
+"""
 import os
-import numpy as np
+import sys
+
 import pandas as pd
 
-def read_tpm_file(file_path):
-    """Reads a TPM file and returns the Gene IDs and TPMs."""
-    table = pd.read_csv(file_path, sep="\t")
-    return table["Gene ID"].values, table["TPM"].values
+
+def sample_name(path):
+    """The sample label for a quant file, e.g. SRR13737862.sra.gene.quant_ref.tab -> SRR13737862."""
+    return os.path.basename(path).split(".")[0]
+
+
+def read_gene_tpms(path):
+    """Reads one StringTie -A table as a gene-indexed TPM series.
+
+    StringTie can report the same gene ID on more than one line - it does so in the U2OS data, for
+    gene:ENSG00000242759 - so the duplicates are summed rather than left to collide in the join.
+    """
+    table = pd.read_csv(path, sep="\t", usecols=["Gene ID", "TPM"])
+    return table.groupby("Gene ID")["TPM"].sum()
+
+
+def build_matrix(input_files):
+    """Genes down the rows, samples across the columns, aligned on gene ID.
+
+    pandas aligns on the index, so a sample that orders its genes differently still lands in the
+    right rows. Both axes are sorted so the output does not depend on the order StringTie happened
+    to emit, nor on the order snakemake happened to pass the files.
+    """
+    tpms_by_sample = {sample_name(path): read_gene_tpms(path) for path in input_files}
+    return pd.concat(tpms_by_sample, axis=1).sort_index().sort_index(axis=1)
+
 
 def main():
     if len(sys.argv) < 3:
@@ -16,30 +44,10 @@ def main():
     output_file = sys.argv[1]
     input_files = sys.argv[2:]
 
-    ids_list = []
-    tpms_list = []
-
-    for file in input_files:
-        currIds, currTpms = read_tpm_file(file)
-        
-        if not ids_list:
-            ids_list = currIds
-        elif not np.array_equal(currIds, ids_list):
-            print(f"Error with IDs in file: {os.path.basename(file)}")
-            sys.exit(1)
-
-        tpms_list.append(currTpms)
-
-    tpms_list.insert(0, ids_list)
-    # NumPy 2.0 removed np.row_stack, which was an alias for np.vstack.
-    dataframe = np.vstack(tpms_list)
-    dataframe[1:, 0] = [os.path.basename(file).split(".")[0] for file in input_files]
-    
-    # Create a DataFrame and save to CSV
-    pddf = pd.DataFrame(dataframe[1:, 1:], index=dataframe[1:, 0], columns=dataframe[0, 1:]).sort_index()
-    pddf.T.to_csv(output_file)
+    build_matrix(input_files).to_csv(output_file)
 
     print(f"Saved summarized data to {output_file}")
+
 
 if __name__ == "__main__":
     main()

--- a/Spritz/workflow/tests/test_summarize_quant.py
+++ b/Spritz/workflow/tests/test_summarize_quant.py
@@ -1,130 +1,205 @@
-"""Tests for SummarizeQuantTab.py and SummarizeQuantGtf.py.
+"""Tests for SummarizeQuantTab.py and SummarizeQuantGtf.py, which build the final TPM matrices.
 
-These two scripts build the final TPM matrices - final/gene_reference_quant.tpms.csv and
-final/transcript_reference_quant.tpms.csv - so they are the last step between StringTie's output
-and what a user reads. They had no coverage, which is how the np.row_stack call below survived
-until the Python upgrade removed it: NumPy 2.0 dropped row_stack, and the failure only surfaced
-34 jobs into the container smoke run.
-
-Two pre-existing defects are captured here as xfail rather than asserted as correct, so that
-fixing them turns the tests green loudly instead of silently. See the tracking issue.
+Fixtures mirror the U2OS run: Ensembl-style identifiers, StringTie's column header and filename
+pattern, gene orders that differ between samples, and a duplicated gene ID.
 """
 import csv
 
+import pytest
+
 from conftest import run_script
 
-GENE_TAB = (
-    "Gene ID\tGene Name\tReference\tStrand\tStart\tEnd\tCoverage\tFPKM\tTPM\n"
-    "YAL001C\tTFC3\tI\t-\t151006\t147594\t3.7\t12.5\t20.1\n"
-    "YAL002W\tVPS8\tI\t+\t143707\t147531\t1.2\t4.25\t6.83\n"
-    "YAL003W\tEFB1\tI\t+\t142174\t142253\t9.9\t101.0\t162.4\n"
-)
+TAB_HEADER = "Gene ID\tGene Name\tReference\tStrand\tStart\tEnd\tCoverage\tFPKM\tTPM"
 
-TRANSCRIPT_GTF = (
-    "# stringtie output\n"
-    'I\tStringTie\ttranscript\t147594\t151006\t1000\t-\t.\tgene_id "YAL001C"; '
-    'transcript_id "YAL001C_mRNA"; cov "3.7"; FPKM "12.500000"; TPM "20.100000";\n'
-    'I\tStringTie\texon\t147594\t151006\t1000\t-\t.\tgene_id "YAL001C"; '
-    'transcript_id "YAL001C_mRNA"; cov "3.7";\n'
-    'I\tStringTie\ttranscript\t143707\t147531\t1000\t+\t.\tgene_id "YAL002W"; '
-    'transcript_id "YAL002W_mRNA"; cov "1.2"; FPKM "4.250000"; TPM "6.830000";\n'
-    'I\tStringTie\ttranscript\t142174\t142253\t1000\t+\t.\tgene_id "YAL003W"; '
-    'transcript_id "YAL003W_mRNA"; cov "9.9"; FPKM "101.000000"; TPM "162.400000";\n'
-)
+GENE_A = "gene:ENSG00000223972"
+GENE_B = "gene:ENSG00000227232"
+GENE_C = "gene:ENSG00000278267"
+DUPLICATED_GENE = "gene:ENSG00000242759"
+
+TRANSCRIPT_A = "transcript:ENST00000450305"
+TRANSCRIPT_B = "transcript:ENST00000456328"
+TRANSCRIPT_C = "transcript:ENST00000488147"
+
+
+def write_tab(tmp_path, sample, genes_to_tpms):
+    """Writes a StringTie -A gene abundance table, preserving the given gene order."""
+    path = tmp_path / f"{sample}.fq.gene.quant_ref.tab"
+    lines = [TAB_HEADER]
+    for index, (gene, tpm) in enumerate(genes_to_tpms, start=1):
+        lines.append(
+            f"{gene}\t-\t1\t+\t{1000 * index}\t{1000 * index + 500}\t1.0\t{tpm / 2:.6f}\t{tpm:.6f}"
+        )
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def write_gtf(tmp_path, sample, transcripts_to_tpms, extra_lines=()):
+    """Writes a StringTie transcript GTF, preserving the given transcript order."""
+    path = tmp_path / f"{sample}.fq.transcript.quant_ref.gtf"
+    lines = ["# stringtie -e -B -G reference.gff"]
+    for index, (transcript, tpm) in enumerate(transcripts_to_tpms, start=1):
+        start, end = 1000 * index, 1000 * index + 500
+        lines.append(
+            f'1\thavana\ttranscript\t{start}\t{end}\t.\t+\t.\t'
+            f'gene_id "gene:ENSG0000000000{index}"; transcript_id "{transcript}"; '
+            f'cov "1.0"; FPKM "{tpm / 2:.6f}"; TPM "{tpm:.6f}";'
+        )
+    lines.extend(extra_lines)
+    path.write_text("\n".join(lines) + "\n")
+    return path
 
 
 def read_matrix(path):
-    """Reads the written CSV into (sample_columns, {row_id: {sample: value}})."""
+    """Reads the written CSV as {row_id: {sample: float}}, plus the sample column order."""
     with open(path, newline="") as handle:
         rows = list(csv.reader(handle))
     samples = rows[0][1:]
-    return samples, {row[0]: dict(zip(samples, row[1:])) for row in rows[1:]}
+    matrix = {row[0]: {s: float(v) for s, v in zip(samples, row[1:])} for row in rows[1:]}
+    return samples, matrix
 
 
 class TestSummarizeQuantTab:
-    def test_runs_and_writes_a_matrix(self, tmp_path):
-        """Regression guard for the NumPy 2.0 removal of np.row_stack.
-
-        Before the fix this died with AttributeError: module 'numpy' has no attribute
-        'row_stack', which is what took down make_gene_quant_dataframe_ref.
-        """
-        quant = tmp_path / "SRR13737862.sra.gene.quant_ref.tab"
-        quant.write_text(GENE_TAB)
-        out = tmp_path / "gene_reference_quant.tpms.csv"
+    def test_keeps_every_gene_including_the_first(self, tmp_path):
+        quant = write_tab(tmp_path, "SRR13737862", [(GENE_A, 20.1), (GENE_B, 6.83), (GENE_C, 162.4)])
+        out = tmp_path / "gene.tpms.csv"
 
         result = run_script("SummarizeQuantTab.py", tmp_path, args=[str(out), str(quant)])
-
         assert result.returncode == 0, result.stderr
-        assert out.exists()
+
+        _, matrix = read_matrix(out)
+        assert set(matrix) == {GENE_A, GENE_B, GENE_C}
+        assert matrix[GENE_A]["SRR13737862"] == pytest.approx(20.1)
+
+    def test_summarizes_multiple_samples(self, tmp_path):
+        """The quant rules pass every sample at once, so this is the normal path."""
+        first = write_tab(tmp_path, "sample_one", [(GENE_A, 1.0), (GENE_B, 2.0)])
+        second = write_tab(tmp_path, "sample_two", [(GENE_A, 10.0), (GENE_B, 20.0)])
+        out = tmp_path / "gene.tpms.csv"
+
+        result = run_script("SummarizeQuantTab.py", tmp_path, args=[str(out), str(first), str(second)])
+        assert result.returncode == 0, result.stderr
+
         samples, matrix = read_matrix(out)
-        assert samples == ["SRR13737862"]
-        assert matrix["YAL003W"]["SRR13737862"] == "162.4"
+        assert samples == ["sample_one", "sample_two"]
+        assert matrix[GENE_A] == {"sample_one": pytest.approx(1.0), "sample_two": pytest.approx(10.0)}
+
+    def test_aligns_values_by_gene_id_not_row_position(self, tmp_path):
+        """StringTie emits the same genes in a different order per sample, so the second sample here
+        deliberately reorders them."""
+        first = write_tab(tmp_path, "sample_one", [(GENE_A, 1.0), (GENE_B, 2.0), (GENE_C, 3.0)])
+        second = write_tab(tmp_path, "sample_two", [(GENE_C, 30.0), (GENE_A, 10.0), (GENE_B, 20.0)])
+        out = tmp_path / "gene.tpms.csv"
+
+        run_script("SummarizeQuantTab.py", tmp_path, args=[str(out), str(first), str(second)])
+
+        _, matrix = read_matrix(out)
+        assert matrix[GENE_A] == {"sample_one": pytest.approx(1.0), "sample_two": pytest.approx(10.0)}
+        assert matrix[GENE_B] == {"sample_one": pytest.approx(2.0), "sample_two": pytest.approx(20.0)}
+        assert matrix[GENE_C] == {"sample_one": pytest.approx(3.0), "sample_two": pytest.approx(30.0)}
+
+    def test_sums_duplicated_gene_ids(self, tmp_path):
+        """StringTie reports gene:ENSG00000242759 on two lines in the U2OS tables."""
+        quant = write_tab(
+            tmp_path, "SRR13737862",
+            [(GENE_A, 1.0), (DUPLICATED_GENE, 0.882933), (DUPLICATED_GENE, 0.0)],
+        )
+        out = tmp_path / "gene.tpms.csv"
+
+        result = run_script("SummarizeQuantTab.py", tmp_path, args=[str(out), str(quant)])
+        assert result.returncode == 0, result.stderr
+
+        _, matrix = read_matrix(out)
+        assert matrix[DUPLICATED_GENE]["SRR13737862"] == pytest.approx(0.882933)
+        assert len(matrix) == 2, "a duplicated gene must collapse to one row, not appear twice"
+
+    def test_sample_name_comes_from_the_filename(self, tmp_path):
+        quant = write_tab(tmp_path, "1_130130_AH03CYADXX_P262_190E_index14", [(GENE_A, 1.0)])
+        out = tmp_path / "gene.tpms.csv"
+
+        run_script("SummarizeQuantTab.py", tmp_path, args=[str(out), str(quant)])
+
+        samples, _ = read_matrix(out)
+        assert samples == ["1_130130_AH03CYADXX_P262_190E_index14"], (
+            "the sample label is the filename up to the first dot, and must not be truncated"
+        )
 
     def test_usage_error_without_enough_arguments(self, tmp_path):
         result = run_script("SummarizeQuantTab.py", tmp_path, args=["only-the-output"])
         assert result.returncode == 1
         assert "Usage" in result.stdout
 
-    def test_keeps_every_gene(self, tmp_path):
-        """KNOWN BROKEN: the first gene of every file is dropped.
-
-        `dataframe[1:, 0] = [sample names]` overwrites column 0 - which holds real data,
-        because no placeholder cell was prepended to the ID row - and the subsequent
-        `[1:, 1:]` slice then discards it. So the first gene's TPM is destroyed and the
-        gene disappears from the output entirely.
-        """
-        quant = tmp_path / "SRR13737862.sra.gene.quant_ref.tab"
-        quant.write_text(GENE_TAB)
-        out = tmp_path / "gene_reference_quant.tpms.csv"
-
-        run_script("SummarizeQuantTab.py", tmp_path, args=[str(out), str(quant)])
-
-        _, matrix = read_matrix(out)
-        if "YAL001C" not in matrix:
-            import pytest
-
-            pytest.xfail("first gene dropped; see the SummarizeQuant data-loss issue")
-        assert matrix["YAL001C"]["SRR13737862"] == "20.1"
-
 
 class TestSummarizeQuantGtf:
-    def test_runs_and_writes_a_matrix(self, tmp_path):
-        """Regression guard for the NumPy 2.0 removal of np.row_stack."""
-        gtf = tmp_path / "SRR13737862.sra.transcript.quant_ref.gtf"
-        gtf.write_text(TRANSCRIPT_GTF)
-        out = tmp_path / "transcript_reference_quant.tpms.csv"
+    def test_keeps_every_transcript_including_the_first(self, tmp_path):
+        gtf = write_gtf(tmp_path, "SRR13737862",
+                        [(TRANSCRIPT_A, 20.1), (TRANSCRIPT_B, 6.83), (TRANSCRIPT_C, 162.4)])
+        out = tmp_path / "transcript.tpms.csv"
 
         result = run_script("SummarizeQuantGtf.py", tmp_path, args=[str(out), str(gtf)])
-
         assert result.returncode == 0, result.stderr
-        assert out.exists()
+
+        _, matrix = read_matrix(out)
+        assert set(matrix) == {TRANSCRIPT_A, TRANSCRIPT_B, TRANSCRIPT_C}
+        assert matrix[TRANSCRIPT_A]["SRR13737862"] == pytest.approx(20.1)
+
+    def test_summarizes_multiple_samples(self, tmp_path):
+        first = write_gtf(tmp_path, "sample_one", [(TRANSCRIPT_A, 1.0), (TRANSCRIPT_B, 2.0)])
+        second = write_gtf(tmp_path, "sample_two", [(TRANSCRIPT_A, 10.0), (TRANSCRIPT_B, 20.0)])
+        out = tmp_path / "transcript.tpms.csv"
+
+        result = run_script("SummarizeQuantGtf.py", tmp_path, args=[str(out), str(first), str(second)])
+        assert result.returncode == 0, result.stderr
+
         samples, matrix = read_matrix(out)
-        assert samples == ["SRR13737862"]
-        assert matrix["YAL003W_mRNA"]["SRR13737862"] == "162.400000"
+        assert samples == ["sample_one", "sample_two"]
+        assert matrix[TRANSCRIPT_B] == {"sample_one": pytest.approx(2.0), "sample_two": pytest.approx(20.0)}
 
-    def test_ignores_non_transcript_rows(self, tmp_path):
-        """Only `transcript` features carry TPM; exon rows must not become columns."""
-        gtf = tmp_path / "SRR13737862.sra.transcript.quant_ref.gtf"
-        gtf.write_text(TRANSCRIPT_GTF)
-        out = tmp_path / "transcript_reference_quant.tpms.csv"
+    def test_aligns_values_by_transcript_id_not_row_position(self, tmp_path):
+        first = write_gtf(tmp_path, "sample_one",
+                          [(TRANSCRIPT_A, 1.0), (TRANSCRIPT_B, 2.0), (TRANSCRIPT_C, 3.0)])
+        second = write_gtf(tmp_path, "sample_two",
+                           [(TRANSCRIPT_C, 30.0), (TRANSCRIPT_A, 10.0), (TRANSCRIPT_B, 20.0)])
+        out = tmp_path / "transcript.tpms.csv"
+
+        run_script("SummarizeQuantGtf.py", tmp_path, args=[str(out), str(first), str(second)])
+
+        _, matrix = read_matrix(out)
+        assert matrix[TRANSCRIPT_A] == {"sample_one": pytest.approx(1.0), "sample_two": pytest.approx(10.0)}
+        assert matrix[TRANSCRIPT_C] == {"sample_one": pytest.approx(3.0), "sample_two": pytest.approx(30.0)}
+
+    def test_ignores_comments_and_non_transcript_features(self, tmp_path):
+        """Only `transcript` rows carry TPM."""
+        exon = (
+            '1\thavana\texon\t1000\t1500\t.\t+\t.\t'
+            f'gene_id "gene:ENSG000000000001"; transcript_id "{TRANSCRIPT_A}"; cov "1.0";'
+        )
+        gtf = write_gtf(tmp_path, "SRR13737862", [(TRANSCRIPT_A, 20.1)], extra_lines=[exon])
+        out = tmp_path / "transcript.tpms.csv"
 
         run_script("SummarizeQuantGtf.py", tmp_path, args=[str(out), str(gtf)])
 
         _, matrix = read_matrix(out)
-        assert all(not key.endswith("exon") for key in matrix)
-        assert len(matrix) <= 3
+        assert set(matrix) == {TRANSCRIPT_A}
+        assert matrix[TRANSCRIPT_A]["SRR13737862"] == pytest.approx(20.1)
 
-    def test_keeps_every_transcript(self, tmp_path):
-        """KNOWN BROKEN: same first-record loss as the .tab script."""
-        gtf = tmp_path / "SRR13737862.sra.transcript.quant_ref.gtf"
-        gtf.write_text(TRANSCRIPT_GTF)
-        out = tmp_path / "transcript_reference_quant.tpms.csv"
+    def test_parses_attribute_values_containing_spaces(self, tmp_path):
+        """A --merge GTF carries gene_name, whose value can contain spaces."""
+        line = (
+            '1\thavana\ttranscript\t1000\t1500\t.\t+\t.\t'
+            f'gene_id "gene:ENSG000000000001"; transcript_id "{TRANSCRIPT_A}"; '
+            'ref_gene_name "some gene with spaces"; cov "1.0"; FPKM "10.0"; TPM "20.100000";'
+        )
+        gtf = tmp_path / "SRR13737862.fq.transcript.quant_ref.gtf"
+        gtf.write_text(line + "\n")
+        out = tmp_path / "transcript.tpms.csv"
 
-        run_script("SummarizeQuantGtf.py", tmp_path, args=[str(out), str(gtf)])
+        result = run_script("SummarizeQuantGtf.py", tmp_path, args=[str(out), str(gtf)])
+        assert result.returncode == 0, result.stderr
 
         _, matrix = read_matrix(out)
-        if "YAL001C_mRNA" not in matrix:
-            import pytest
+        assert matrix[TRANSCRIPT_A]["SRR13737862"] == pytest.approx(20.1)
 
-            pytest.xfail("first transcript dropped; see the SummarizeQuant data-loss issue")
-        assert matrix["YAL001C_mRNA"]["SRR13737862"] == "20.100000"
+    def test_usage_error_without_enough_arguments(self, tmp_path):
+        result = run_script("SummarizeQuantGtf.py", tmp_path, args=["only-the-output"])
+        assert result.returncode == 1
+        assert "Usage" in result.stdout

--- a/Spritz/workflow/tests/test_summarize_quant.py
+++ b/Spritz/workflow/tests/test_summarize_quant.py
@@ -1,0 +1,130 @@
+"""Tests for SummarizeQuantTab.py and SummarizeQuantGtf.py.
+
+These two scripts build the final TPM matrices - final/gene_reference_quant.tpms.csv and
+final/transcript_reference_quant.tpms.csv - so they are the last step between StringTie's output
+and what a user reads. They had no coverage, which is how the np.row_stack call below survived
+until the Python upgrade removed it: NumPy 2.0 dropped row_stack, and the failure only surfaced
+34 jobs into the container smoke run.
+
+Two pre-existing defects are captured here as xfail rather than asserted as correct, so that
+fixing them turns the tests green loudly instead of silently. See the tracking issue.
+"""
+import csv
+
+from conftest import run_script
+
+GENE_TAB = (
+    "Gene ID\tGene Name\tReference\tStrand\tStart\tEnd\tCoverage\tFPKM\tTPM\n"
+    "YAL001C\tTFC3\tI\t-\t151006\t147594\t3.7\t12.5\t20.1\n"
+    "YAL002W\tVPS8\tI\t+\t143707\t147531\t1.2\t4.25\t6.83\n"
+    "YAL003W\tEFB1\tI\t+\t142174\t142253\t9.9\t101.0\t162.4\n"
+)
+
+TRANSCRIPT_GTF = (
+    "# stringtie output\n"
+    'I\tStringTie\ttranscript\t147594\t151006\t1000\t-\t.\tgene_id "YAL001C"; '
+    'transcript_id "YAL001C_mRNA"; cov "3.7"; FPKM "12.500000"; TPM "20.100000";\n'
+    'I\tStringTie\texon\t147594\t151006\t1000\t-\t.\tgene_id "YAL001C"; '
+    'transcript_id "YAL001C_mRNA"; cov "3.7";\n'
+    'I\tStringTie\ttranscript\t143707\t147531\t1000\t+\t.\tgene_id "YAL002W"; '
+    'transcript_id "YAL002W_mRNA"; cov "1.2"; FPKM "4.250000"; TPM "6.830000";\n'
+    'I\tStringTie\ttranscript\t142174\t142253\t1000\t+\t.\tgene_id "YAL003W"; '
+    'transcript_id "YAL003W_mRNA"; cov "9.9"; FPKM "101.000000"; TPM "162.400000";\n'
+)
+
+
+def read_matrix(path):
+    """Reads the written CSV into (sample_columns, {row_id: {sample: value}})."""
+    with open(path, newline="") as handle:
+        rows = list(csv.reader(handle))
+    samples = rows[0][1:]
+    return samples, {row[0]: dict(zip(samples, row[1:])) for row in rows[1:]}
+
+
+class TestSummarizeQuantTab:
+    def test_runs_and_writes_a_matrix(self, tmp_path):
+        """Regression guard for the NumPy 2.0 removal of np.row_stack.
+
+        Before the fix this died with AttributeError: module 'numpy' has no attribute
+        'row_stack', which is what took down make_gene_quant_dataframe_ref.
+        """
+        quant = tmp_path / "SRR13737862.sra.gene.quant_ref.tab"
+        quant.write_text(GENE_TAB)
+        out = tmp_path / "gene_reference_quant.tpms.csv"
+
+        result = run_script("SummarizeQuantTab.py", tmp_path, args=[str(out), str(quant)])
+
+        assert result.returncode == 0, result.stderr
+        assert out.exists()
+        samples, matrix = read_matrix(out)
+        assert samples == ["SRR13737862"]
+        assert matrix["YAL003W"]["SRR13737862"] == "162.4"
+
+    def test_usage_error_without_enough_arguments(self, tmp_path):
+        result = run_script("SummarizeQuantTab.py", tmp_path, args=["only-the-output"])
+        assert result.returncode == 1
+        assert "Usage" in result.stdout
+
+    def test_keeps_every_gene(self, tmp_path):
+        """KNOWN BROKEN: the first gene of every file is dropped.
+
+        `dataframe[1:, 0] = [sample names]` overwrites column 0 - which holds real data,
+        because no placeholder cell was prepended to the ID row - and the subsequent
+        `[1:, 1:]` slice then discards it. So the first gene's TPM is destroyed and the
+        gene disappears from the output entirely.
+        """
+        quant = tmp_path / "SRR13737862.sra.gene.quant_ref.tab"
+        quant.write_text(GENE_TAB)
+        out = tmp_path / "gene_reference_quant.tpms.csv"
+
+        run_script("SummarizeQuantTab.py", tmp_path, args=[str(out), str(quant)])
+
+        _, matrix = read_matrix(out)
+        if "YAL001C" not in matrix:
+            import pytest
+
+            pytest.xfail("first gene dropped; see the SummarizeQuant data-loss issue")
+        assert matrix["YAL001C"]["SRR13737862"] == "20.1"
+
+
+class TestSummarizeQuantGtf:
+    def test_runs_and_writes_a_matrix(self, tmp_path):
+        """Regression guard for the NumPy 2.0 removal of np.row_stack."""
+        gtf = tmp_path / "SRR13737862.sra.transcript.quant_ref.gtf"
+        gtf.write_text(TRANSCRIPT_GTF)
+        out = tmp_path / "transcript_reference_quant.tpms.csv"
+
+        result = run_script("SummarizeQuantGtf.py", tmp_path, args=[str(out), str(gtf)])
+
+        assert result.returncode == 0, result.stderr
+        assert out.exists()
+        samples, matrix = read_matrix(out)
+        assert samples == ["SRR13737862"]
+        assert matrix["YAL003W_mRNA"]["SRR13737862"] == "162.400000"
+
+    def test_ignores_non_transcript_rows(self, tmp_path):
+        """Only `transcript` features carry TPM; exon rows must not become columns."""
+        gtf = tmp_path / "SRR13737862.sra.transcript.quant_ref.gtf"
+        gtf.write_text(TRANSCRIPT_GTF)
+        out = tmp_path / "transcript_reference_quant.tpms.csv"
+
+        run_script("SummarizeQuantGtf.py", tmp_path, args=[str(out), str(gtf)])
+
+        _, matrix = read_matrix(out)
+        assert all(not key.endswith("exon") for key in matrix)
+        assert len(matrix) <= 3
+
+    def test_keeps_every_transcript(self, tmp_path):
+        """KNOWN BROKEN: same first-record loss as the .tab script."""
+        gtf = tmp_path / "SRR13737862.sra.transcript.quant_ref.gtf"
+        gtf.write_text(TRANSCRIPT_GTF)
+        out = tmp_path / "transcript_reference_quant.tpms.csv"
+
+        run_script("SummarizeQuantGtf.py", tmp_path, args=[str(out), str(gtf)])
+
+        _, matrix = read_matrix(out)
+        if "YAL001C_mRNA" not in matrix:
+            import pytest
+
+            pytest.xfail("first transcript dropped; see the SummarizeQuant data-loss issue")
+        assert matrix["YAL001C_mRNA"]["SRR13737862"] == "20.100000"

--- a/Spritz/workflow/tests/test_summarize_quant.py
+++ b/Spritz/workflow/tests/test_summarize_quant.py
@@ -128,6 +128,18 @@ class TestSummarizeQuantTab:
         assert result.returncode == 1
         assert "Usage" in result.stdout
 
+    def test_fails_loudly_if_the_expected_columns_are_missing(self, tmp_path):
+        """StringTie is unpinned, so its output can change; that must not pass silently."""
+        quant = tmp_path / "SRR13737862.fq.gene.quant_ref.tab"
+        quant.write_text("Gene ID\tGene Name\tTPMs\ngene:ENSG1\t-\t1.0\n")
+        out = tmp_path / "gene.tpms.csv"
+
+        result = run_script("SummarizeQuantTab.py", tmp_path, args=[str(out), str(quant)])
+
+        assert result.returncode != 0
+        assert "Gene ID" in result.stderr and "TPM" in result.stderr
+        assert not out.exists(), "no matrix should be written when the input is not understood"
+
 
 class TestSummarizeQuantGtf:
     def test_keeps_every_transcript_including_the_first(self, tmp_path):
@@ -203,3 +215,33 @@ class TestSummarizeQuantGtf:
         result = run_script("SummarizeQuantGtf.py", tmp_path, args=["only-the-output"])
         assert result.returncode == 1
         assert "Usage" in result.stdout
+
+    def test_fails_loudly_if_a_transcript_row_has_no_tpm(self, tmp_path):
+        """A renamed or dropped TPM attribute must stop the run, not yield an empty matrix."""
+        gtf = tmp_path / "SRR13737862.fq.transcript.quant_ref.gtf"
+        gtf.write_text(
+            '1\thavana\ttranscript\t1000\t1500\t.\t+\t.\t'
+            f'gene_id "g1"; transcript_id "{TRANSCRIPT_A}"; cov "1.0"; FPKM "10.0";\n'
+        )
+        out = tmp_path / "transcript.tpms.csv"
+
+        result = run_script("SummarizeQuantGtf.py", tmp_path, args=[str(out), str(gtf)])
+
+        assert result.returncode != 0
+        assert "TPM" in result.stderr
+        assert not out.exists()
+
+    def test_fails_loudly_if_no_transcript_features_are_present(self, tmp_path):
+        """If StringTie stopped labelling these rows 'transcript', say so rather than writing nothing."""
+        gtf = tmp_path / "SRR13737862.fq.transcript.quant_ref.gtf"
+        gtf.write_text(
+            "# stringtie\n"
+            '1\thavana\texon\t1000\t1500\t.\t+\t.\tgene_id "g1"; transcript_id "t1"; TPM "1.0";\n'
+        )
+        out = tmp_path / "transcript.tpms.csv"
+
+        result = run_script("SummarizeQuantGtf.py", tmp_path, args=[str(out), str(gtf)])
+
+        assert result.returncode != 0
+        assert "transcript" in result.stderr
+        assert not out.exists()

--- a/Spritz/workflow/tests/test_summarize_quant.py
+++ b/Spritz/workflow/tests/test_summarize_quant.py
@@ -97,6 +97,26 @@ class TestSummarizeQuantTab:
         assert matrix[GENE_B] == {"sample_one": pytest.approx(2.0), "sample_two": pytest.approx(20.0)}
         assert matrix[GENE_C] == {"sample_one": pytest.approx(3.0), "sample_two": pytest.approx(30.0)}
 
+    def test_takes_the_union_when_samples_report_different_genes(self, tmp_path):
+        """Reported in #237: two samples whose tables had 60,633 and 60,635 lines.
+
+        A gene absent from one sample is left empty rather than filled with 0, since StringTie not
+        reporting a gene is not the same as measuring it at zero.
+        """
+        first = write_tab(tmp_path, "sample_one", [(GENE_A, 1.0), (GENE_B, 2.0)])
+        second = write_tab(tmp_path, "sample_two", [(GENE_B, 20.0), (GENE_C, 30.0)])
+        out = tmp_path / "gene.tpms.csv"
+
+        result = run_script("SummarizeQuantTab.py", tmp_path, args=[str(out), str(first), str(second)])
+        assert result.returncode == 0, result.stderr
+
+        with open(out) as handle:
+            rows = {line.split(",")[0]: line.strip().split(",")[1:] for line in handle}
+        assert set(rows) - {"Gene ID"} == {GENE_A, GENE_B, GENE_C}
+        assert rows[GENE_A] == ["1.0", ""], "a gene missing from a sample is empty, not zero"
+        assert rows[GENE_C] == ["", "30.0"]
+        assert rows[GENE_B] == ["2.0", "20.0"]
+
     def test_sums_duplicated_gene_ids(self, tmp_path):
         """StringTie reports gene:ENSG00000242759 on two lines in the U2OS tables."""
         quant = write_tab(


### PR DESCRIPTION
Closes #257
Closes #237

Two things, coupled because the second was uncovered by the first: NumPy 2 removed a function these
scripts used, and looking at why led to three real defects in them.

## Part 1 - the interpreter upgrade

Python 3.8 went end of life in October 2024, and two other pins are welded to it.

| Pin | Before | After | Why it had to move |
|---|---|---|---|
| `python` | 3.8 | 3.13 | end of life Oct 2024 |
| `snakemake-minimal` | 5.27.4 | 9.25.1 | 5.27.4 needs `ratelimiter`, which caps python at **3.10** |
| `samtools` | 1.11 | 1.24 | pins `zlib <3` and an old ncurses; will not solve past python 3.10 |
| `numpy` | `=1.19.4` | unpinned | no build exists past python 3.9 |

Python 3.10 is itself out of support, so stopping there would swap one dead interpreter for another;
reaching a supported one requires a snakemake that dropped `ratelimiter`, which is why the snakemake
migration is absorbed here rather than deferred. `samtools` is bumped in `variants.yaml` too, which
pins no python and so would have kept solving at 1.11 - leaving two different samtools versions
reading the same BAMs. `gatk4` and `java-jdk` there are also old, but bumping gatk4 changes variant
calls, so that is deliberately left alone.

Verified: all 11 environment files solve for `linux-64` under strict channel priority, and the
**planned DAG is byte-identical** to the 5.27.4 baseline for all four analysis combinations
(`quant` 25 jobs, `variant` 38, `isoform` 36, all three 64).

Also drops `mamba` and `--conda-frontend mamba`: snakemake 9 accepts the flag but reports
`Ignoring the alternative conda frontend setting (mamba)` and uses conda, which solves via libmamba
itself.

## Part 2 - the quant matrix scripts :rotating_light:

`np.row_stack` was removed in NumPy 2.0, which broke `make_gene_quant_dataframe_ref` and
`make_isoform_quant_dataframe_ref` 34 jobs into the container run. Substituting `np.vstack` fixed the
crash, but these scripts had no test coverage, and adding it surfaced three genuine defects.

Both scripts built a labelled table inside a raw 2-D numpy array, using row 0 as a header and column
0 as an index - but never reserved a cell for the corner, so column 0 held real data:

```python
dataframe[1:, 0] = [sample names]   # overwrites the first gene's TPM
dataframe[1:, 1:]                   # then slices that column away
```

1. **The first gene or transcript of every file was dropped.** An off-by-one from the missing corner
   cell, not a loop bound.
2. **Any run with two or more samples produced nothing.** `if not ids_list:` raises
   `ValueError: truth value of an array ... is ambiguous` once `ids_list` is an ndarray. The quant
   rules pass every sample at once, so this is the normal path - and it is exactly what #237
   reported in 2023.
3. **Values were placed by row position.** StringTie emits the same gene set in a *different order*
   per sample, so TPMs were attributed to the wrong genes.

The `np.array_equal` guard meant to catch (3) is unreachable, because (2) raises first. Fixing only
(2) would make the guard fire and `exit(1)` on real data, so multi-sample quant still would not work.
The positional-stacking design is what is wrong.

Both are now a pandas join on ID. Ordering cannot matter, nothing is consumed as a label, duplicated
IDs are summed - the U2OS tables need that for `gene:ENSG00000242759`, which StringTie reports at two
disjoint loci - and samples reporting different gene sets take the union, leaving a missing gene
empty rather than zero.

### Verified against the real U2OS v0.3.4 run, not fixtures alone

| | result |
|---|---|
| gene matrix, 9 samples, 60,666 genes | **0 missing, 0 unexpected, 0 value mismatches** vs the source tables |
| the shipped v0.3.4 matrix, same comparison | **37,260 of 60,665 rows disagree** with their source |
| transcript matrix, 234,392 transcripts | 0 missing, 0 mismatched |
| the old script on those 9 samples | could not run at all |

### Output changes, deliberately

Matrices gain the record that was dropped, put every value on the correct feature, are row-sorted by
ID, carry the ID column name in the corner cell, and render numbers as parsed floats, so a TPM
previously written `162.400000` is now `162.4`.

### Failing loudly

A missing `TPM` attribute used to be skipped silently, so a StringTie output change would have
produced an empty matrix and exit 0. It now raises, naming the file, line and attributes found - and
`stringtie` is unpinned, so what produces these files can move between environment builds. Checked
upstream: no GTF format or attribute-name changes are documented from 2.1.6 to 3.0.3, so the parsing
is not the exposure; the exposure was the silent skip.

## Tests

39 python tests, on fixtures shaped like the U2OS data - Ensembl identifiers, StringTie's header and
filename pattern, per-sample gene orders that disagree, a duplicated gene ID, mismatched gene sets -
with one test per failure mode above. The `dockerbuild` smoke run exercises the single-sample path
end to end; the multi-sample path is covered by unit tests and by the nine-sample U2OS run above.