### PR TITLE
Finish the .NET 10 pin sweep missed by #252

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v6
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 10.0.x
 
     - name: Restore dependencies
       run: dotnet restore Spritz/Spritz.sln


### PR DESCRIPTION
`build.yml` still pinned `dotnet-version: 6.0.x` in the `external-service-tests` job. #252 moved the
`builds` and `dockerbuild` jobs to `10.0.x` and missed this one.

It has been passing **only by accident**: `windows-latest` ships newer SDKs preinstalled and this
repo has no `global.json`, so `dotnet build` picks a 10.x SDK regardless of what `setup-dotnet`
installed. And because that job sets `continue-on-error: true`, had it actually broken it would still
have reported success - so this would not have surfaced on its own.

One line.

## Considered and dropped

I had also filtered the `ExternalService` tests out of `release.yml`, on the reasoning that a UniProt
or GitHub outage should not fail a tagged release. That was wrong and has been dropped, so
`release.yml` is untouched here.

`PublishedReleaseIsNotNewerThanCompiledVersion` is the only automated check that
`RunnerEngine.CurrentVersion` was bumped before tagging, and it can only answer that against the live
GitHub releases API - so a release is precisely when it is worth running, not when it should be
skipped. Same for the ptmlist download and parse: if UniProt changed that format, it should block
publishing rather than reach users. Waiting for a service to come back and re-running is the right
trade at release time, even though it is the wrong one on a pull request.