### PR TITLE
Skip the external-service tests on an outage instead of failing them

### DIFF
--- a/Spritz/SpritzBackend/SpritzVersion.cs
+++ b/Spritz/SpritzBackend/SpritzVersion.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 
@@ -22,11 +23,28 @@ namespace SpritzBackend
                 {
                     var json = response.Content.ReadAsStringAsync().Result;
                     JObject deserialized = JObject.Parse(json);
-                    NewestKnownVersion = deserialized["tag_name"].ToString();
-                    var assets = deserialized["assets"].Select(b => b["name"].ToString()).ToList();
+
+                    // The API does not always answer with a release. A rate-limit or error reply is
+                    // still valid JSON - {"message": "API rate limit exceeded for ...", ...} - and has
+                    // no tag_name, so dereferencing it threw NullReferenceException. That surfaced as
+                    // "Object reference not set to an instance of an object" both in CI and in the
+                    // GUI's update dialog, which says nothing about what actually went wrong.
+                    // Leaving the properties null lets the caller distinguish "no answer" from an
+                    // answer it dislikes.
+                    JToken tagName = deserialized["tag_name"];
+                    if (tagName == null)
+                    {
+                        return;
+                    }
+
+                    NewestKnownVersion = tagName.ToString();
+                    var assets = deserialized["assets"]?
+                        .Select(b => b["name"]?.ToString())
+                        .Where(name => name != null)
+                        .ToList() ?? new List<string>();
                     bool containsMsi = assets.Contains("Spritz.msi");
                     if (!IsVersionLower(NewestKnownVersion))
-                        IsMsiAvailableForUpdate = assets.Contains("Spritz.msi");
+                        IsMsiAvailableForUpdate = containsMsi;
                     if (containsMsi)
                         NewestKnownVersionWithMsi = NewestKnownVersion;
                 }

--- a/Spritz/SpritzTest/SpritzModificationsTests.cs
+++ b/Spritz/SpritzTest/SpritzModificationsTests.cs
@@ -21,9 +21,21 @@ namespace SpritzTest
         [Category("ExternalService")]
         public void GetUniProtMods_ParsesModificationsFromDownloadedPtmList()
         {
-            var mods = ProteinAnnotation.GetUniProtMods(TestContext.CurrentContext.TestDirectory);
+            int modificationCount;
+            try
+            {
+                modificationCount = ProteinAnnotation.GetUniProtMods(TestContext.CurrentContext.TestDirectory).Count;
+            }
+            catch (System.Exception exception)
+            {
+                // A failed download is an outage, not a Spritz regression, so it skips rather than fails.
+                // A download that succeeds but parses to nothing still fails below - that would mean the
+                // ptmlist format changed, which is a real break worth reddening the check for.
+                Assert.Ignore($"could not download or read the UniProt ptmlist: {exception.Message}");
+                return;
+            }
 
-            Assert.That(mods, Is.Not.Empty,
+            Assert.That(modificationCount, Is.GreaterThan(0),
                 "no UniProt modifications were parsed from ptmlist.txt; check the download succeeded and the "
                 + "ptmlist format has not changed");
         }

--- a/Spritz/SpritzTest/SpritzVersionTests.cs
+++ b/Spritz/SpritzTest/SpritzVersionTests.cs
@@ -15,18 +15,32 @@ namespace SpritzTest
         /// offline, and the unauthenticated GitHub API is rate limited per IP - which CI runners share - so it
         /// is flaky by nature. It is excluded from the required CI run and executed in a separate
         /// non-blocking job instead.
+        ///
+        /// When the API cannot answer, this reports as SKIPPED rather than failed. The point of the test is to
+        /// nag about bumping RunnerEngine.CurrentVersion, and that nag only carries if a red result means the
+        /// versions really disagree. Rate-limit noise reddening the check trains everyone to ignore it.
         /// </summary>
         [Test]
         [Category("ExternalService")]
         public void PublishedReleaseIsNotNewerThanCompiledVersion()
         {
             SpritzVersion version = new();
-            version.GetVersionNumbersFromWeb();
+            try
+            {
+                version.GetVersionNumbersFromWeb();
+            }
+            catch (System.Exception exception)
+            {
+                Assert.Ignore($"could not reach the GitHub releases API: {exception.Message}");
+            }
 
-            // Distinguish "the API told us nothing" from "the versions disagree". Without this, an API
-            // failure is reported as a version mismatch, which sends the reader to the wrong place.
-            Assert.That(version.NewestKnownVersion, Is.Not.Null.And.Not.Empty,
-                "the GitHub releases API returned no tag_name, so this is an external-service failure rather than a version mismatch");
+            // Distinguish "the API told us nothing" from "the versions disagree", and skip rather than fail in
+            // the first case. A rate-limit reply is valid JSON with no tag_name, which leaves this null.
+            if (string.IsNullOrEmpty(version.NewestKnownVersion))
+            {
+                Assert.Ignore("the GitHub releases API returned no tag_name, most likely a rate limit or an "
+                    + "outage; skipped rather than failed because this is not a version mismatch");
+            }
 
             // SpritzVersion.IsVersionLower(null) throws NullReferenceException rather than returning a
             // value: GetVersionNumber catches FormatException but not a null input. The no-installer case is


### PR DESCRIPTION
The "External-service tests (non-blocking)" job went red on #256 with:

```
PublishedReleaseIsNotNewerThanCompiledVersion
System.NullReferenceException : Object reference not set to an instance of an object.
```

in 58 ms. That was a **GitHub API rate limit**, not a version mismatch. Unauthenticated calls are
capped at 60/hour per IP, hosted runners share addresses, and this job had run repeatedly that day.
The 403 body is valid JSON with no `tag_name`, so `SpritzVersion.cs:25` called `.ToString()` on null.

**The guard I added in #248 was upstream-incomplete.** It checked `NewestKnownVersion` in the test,
but the exception is thrown inside `GetVersionNumbersFromWeb` before the test ever sees a value - so
the test still could not distinguish an outage from a real break, which is exactly what that change
claimed to fix.

## What changed

`GetVersionNumbersFromWeb` returns leaving the properties null when the payload has no `tag_name`,
instead of throwing. That also improves the GUI, which catches this and previously showed users
*"Could not get newest version from web: Object reference not set to an instance of an object."*

Both `ExternalService` tests now `Assert.Ignore` when the service cannot answer, so they report as
**skipped** rather than **failed**. A download that succeeds but parses to nothing still fails - that
would mean the ptmlist format changed, which is a real break worth reddening the check for.

## This protects the nag rather than weakening it

The version test exists to nag about bumping `RunnerEngine.CurrentVersion`, and that nag only carries
weight if a red result means the versions genuinely disagree. Rate-limit noise reddening the check is
what trains everyone to ignore it.

## Verification

Pointed the URL at a 404 endpoint, which returns the same payload shape as a rate-limit reply:

| | before | after |
|---|---|---|
| outage | `NullReferenceException`, run failed | `Failed: 0, Passed: 1, Skipped: 1` |
| live API | passed | `Failed: 0, Passed: 2, Skipped: 0` |

Also checked: there is **no genuine mismatch** right now - the published release,
`RunnerEngine.CurrentVersion` and `Product.wxs` are all `0.3.13`.

## Note on the check not actually being blocking

For the record, this job never blocked merging: `master`'s required checks are `builds` and
`dockerbuild` only, and the workflow *run* conclusion is `success` because of `continue-on-error`.
What it produced was a red X on the checks list and an `UNSTABLE` merge state, which reads as
blocking even though it is not.