### PR TITLE
Make the git tag the single source of truth for the version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,8 +80,13 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore Spritz/SpritzCMD/SpritzCMD.csproj
 
+    # /p:Version matters here, not just in the githubrelease job: RunnerEngine.CurrentVersion is read
+    # from the assembly, and it is written into the config the container consumes. Without this the
+    # published image would report the development default while being tagged with the release version.
     - name: Build SpritzCMD
-      run: dotnet build --no-restore --configuration Release Spritz/SpritzCMD/SpritzCMD.csproj
+      run: |
+        version=$(git describe --tags)
+        dotnet build --no-restore --configuration Release /p:Version=${version} Spritz/SpritzCMD/SpritzCMD.csproj
 
     - name: Build docker image
       run: docker build -t spritz ./Spritz/

--- a/Spritz/Directory.Build.props
+++ b/Spritz/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <!-- Single source of truth for the version. release.yml passes /p:Version from the git tag,
+         and a command-line property always wins over this default, so tagging is the only thing
+         that decides what a release reports. This value is what local and CI builds use, and so
+         also the Docker Hub tag a development build of the GUI pulls by default. -->
+    <Version Condition=" '$(Version)' == '' ">0.3.13</Version>
+  </PropertyGroup>
+</Project>

--- a/Spritz/SpritzBackend/RunnerEngine.cs
+++ b/Spritz/SpritzBackend/RunnerEngine.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using YamlDotNet.RepresentationModel;
@@ -20,7 +21,29 @@ namespace SpritzBackend
         public string SnakemakeCommand { get; private set; }
         public string SpritzCMDCommand { get; set; }
 
-        public static readonly string CurrentVersion = "0.3.13";
+        /// <summary>
+        /// The version this build reports, and the Docker Hub tag it pulls. Read from the assembly rather
+        /// than hardcoded, so the MSBuild Version property is the only place it is set: Directory.Build.props
+        /// holds the development default and release.yml overrides it with /p:Version from the git tag.
+        /// Previously this literal had to be edited in step with Product.wxs and the tag by hand.
+        /// </summary>
+        public static readonly string CurrentVersion = ReadCompiledVersion();
+
+        private static string ReadCompiledVersion()
+        {
+            // InformationalVersion carries the full Version string. Source-link style builds append "+<sha>",
+            // which is not part of the version and is not in the Docker tag, so it is trimmed.
+            string informational = typeof(RunnerEngine).Assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+            if (!string.IsNullOrWhiteSpace(informational))
+            {
+                return informational.Split('+')[0];
+            }
+
+            // AssemblyVersion is always present, but is four-part, so take the first three to match the tag.
+            return typeof(RunnerEngine).Assembly.GetName().Version?.ToString(3) ?? "0.0.0";
+        }
+
         public static readonly bool PrebuiltSpritzMods = true; // always using prebuilt library now
         public RunnerEngine(Tuple<string, SpritzOptions> task, string outputFolder)
         {

--- a/Spritz/SpritzBackend/SpritzVersion.cs
+++ b/Spritz/SpritzBackend/SpritzVersion.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 
@@ -22,11 +23,28 @@ namespace SpritzBackend
                 {
                     var json = response.Content.ReadAsStringAsync().Result;
                     JObject deserialized = JObject.Parse(json);
-                    NewestKnownVersion = deserialized["tag_name"].ToString();
-                    var assets = deserialized["assets"].Select(b => b["name"].ToString()).ToList();
+
+                    // The API does not always answer with a release. A rate-limit or error reply is
+                    // still valid JSON - {"message": "API rate limit exceeded for ...", ...} - and has
+                    // no tag_name, so dereferencing it threw NullReferenceException. That surfaced as
+                    // "Object reference not set to an instance of an object" both in CI and in the
+                    // GUI's update dialog, which says nothing about what actually went wrong.
+                    // Leaving the properties null lets the caller distinguish "no answer" from an
+                    // answer it dislikes.
+                    JToken tagName = deserialized["tag_name"];
+                    if (tagName == null)
+                    {
+                        return;
+                    }
+
+                    NewestKnownVersion = tagName.ToString();
+                    var assets = deserialized["assets"]?
+                        .Select(b => b["name"]?.ToString())
+                        .Where(name => name != null)
+                        .ToList() ?? new List<string>();
                     bool containsMsi = assets.Contains("Spritz.msi");
                     if (!IsVersionLower(NewestKnownVersion))
-                        IsMsiAvailableForUpdate = assets.Contains("Spritz.msi");
+                        IsMsiAvailableForUpdate = containsMsi;
                     if (containsMsi)
                         NewestKnownVersionWithMsi = NewestKnownVersion;
                 }

--- a/Spritz/SpritzInstaller/Product.wxs
+++ b/Spritz/SpritzInstaller/Product.wxs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <?define SpritzTargetDir=$(var.SpritzGUI.TargetDir)?>
-	<Product Id="*" Name="Spritz" Language="1033" Version="0.3.13" Manufacturer="Smith Group" UpgradeCode="5af693cd-1556-4ef4-9c24-e1242de081de">
+	<Product Id="*" Name="Spritz" Language="1033" Version="$(var.Version)" Manufacturer="Smith Group" UpgradeCode="5af693cd-1556-4ef4-9c24-e1242de081de">
 		<Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
     <MediaTemplate EmbedCab="yes"/>
 

--- a/Spritz/SpritzInstaller/SpritzInstaller.wixproj
+++ b/Spritz/SpritzInstaller/SpritzInstaller.wixproj
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" InitialTargets="EnsureWixToolsetInstalled" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Imported explicitly: this is an old-style project that does not import Microsoft.Common.props,
+       so it would otherwise never see Directory.Build.props and would need its own copy of the
+       version default. Importing keeps one source of truth. -->
+  <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props"
+          Condition="Exists('$(MSBuildThisFileDirectory)..\Directory.Build.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -13,13 +18,12 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug</DefineConstants>
+    <DefineConstants>Debug;Version=$(Version)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>
-    </DefineConstants>
+    <DefineConstants>Version=$(Version)</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Maintenance.wxs" />

--- a/Spritz/SpritzTest/RunnerEngineDockerImageTests.cs
+++ b/Spritz/SpritzTest/RunnerEngineDockerImageTests.cs
@@ -1,0 +1,91 @@
+using NUnit.Framework;
+using SpritzBackend;
+using System;
+using System.IO;
+
+namespace SpritzTest
+{
+    /// <summary>
+    /// Covers how RunnerEngine turns a docker image name into a command, which is where
+    /// RunnerEngine.CurrentVersion is actually consumed: the GUI pulls smithlab/spritz:{CurrentVersion},
+    /// so if the compiled version and the published image tag disagree, Spritz pulls an image that does not
+    /// exist. That makes this the user-facing end of the version wiring, and it runs offline.
+    ///
+    /// It also pins the two escape hatches that make local development possible - an explicit tag, and a
+    /// non-smithlab image name - which were previously undocumented behaviour of two bare conditionals.
+    /// </summary>
+    public class RunnerEngineDockerImageTests
+    {
+        private string _temporaryRoot;
+        private RunnerEngine _runner;
+
+        [SetUp]
+        public void SetUp()
+        {
+            // The constructor creates a config directory beside the analysis directory and a resources
+            // directory beside that, so it needs somewhere real to write.
+            _temporaryRoot = Path.Combine(Path.GetTempPath(), "spritz-docker-tests-" + Guid.NewGuid().ToString("N"));
+            string analysisDirectory = Path.Combine(_temporaryRoot, "analysis");
+            Directory.CreateDirectory(analysisDirectory);
+            _runner = new RunnerEngine(null, analysisDirectory);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(_temporaryRoot))
+            {
+                Directory.Delete(_temporaryRoot, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// The default path: the published image is pulled, tagged with the compiled version. This is the
+        /// invariant that ties the version to something a user can actually hit.
+        /// </summary>
+        [Test]
+        public void PublishedImageIsTaggedWithTheCompiledVersionAndPulled()
+        {
+            string command = _runner.GenerateCommandsDry("smithlab/spritz", "SpritzCMD.dll --help");
+
+            Assert.That(command, Does.Contain($"smithlab/spritz:{RunnerEngine.CurrentVersion}"),
+                "the published image must be requested at the compiled version, otherwise Spritz pulls a tag "
+                + "that release.yml never pushed");
+            Assert.That(command, Does.StartWith("docker pull "),
+                "the published image should be pulled before it is run, so users get the released container");
+        }
+
+        /// <summary>
+        /// An explicit tag is honoured verbatim. This is what makes "build a local image and point Spritz at
+        /// it" work, and it must not have the compiled version appended to it.
+        /// </summary>
+        [Test]
+        public void ExplicitTagIsUsedVerbatimAndNotPulled()
+        {
+            string command = _runner.GenerateCommandsDry("spritz:dev", "SpritzCMD.dll --help");
+
+            Assert.That(command, Does.Contain("spritz:dev"));
+            Assert.That(command, Does.Not.Contain($"spritz:dev:{RunnerEngine.CurrentVersion}"),
+                "an image name that already carries a tag must not have the compiled version appended");
+            Assert.That(command, Does.Not.Contain("docker pull"),
+                "a locally built image must not be pulled, or the local build would be replaced by whatever "
+                + "is in the registry under that name");
+        }
+
+        /// <summary>
+        /// A local image named without a tag still gets the compiled version appended - it is only the
+        /// "smithlab" check that suppresses the pull. Asserted so the two conditions stay distinguishable.
+        /// </summary>
+        [Test]
+        public void UntaggedLocalImageGetsTheCompiledVersionButIsNotPulled()
+        {
+            string command = _runner.GenerateCommandsDry("spritz", "SpritzCMD.dll --help");
+
+            Assert.That(command, Does.Contain($"spritz:{RunnerEngine.CurrentVersion}"),
+                "an untagged name has the compiled version appended, so a local image built as plain "
+                + "'spritz' will not be found unless it is tagged with the compiled version");
+            Assert.That(command, Does.Not.Contain("docker pull"),
+                "only image names containing 'smithlab' are pulled");
+        }
+    }
+}

--- a/Spritz/SpritzTest/SpritzModificationsTests.cs
+++ b/Spritz/SpritzTest/SpritzModificationsTests.cs
@@ -21,9 +21,21 @@ namespace SpritzTest
         [Category("ExternalService")]
         public void GetUniProtMods_ParsesModificationsFromDownloadedPtmList()
         {
-            var mods = ProteinAnnotation.GetUniProtMods(TestContext.CurrentContext.TestDirectory);
+            int modificationCount;
+            try
+            {
+                modificationCount = ProteinAnnotation.GetUniProtMods(TestContext.CurrentContext.TestDirectory).Count;
+            }
+            catch (System.Exception exception)
+            {
+                // A failed download is an outage, not a Spritz regression, so it skips rather than fails.
+                // A download that succeeds but parses to nothing still fails below - that would mean the
+                // ptmlist format changed, which is a real break worth reddening the check for.
+                Assert.Ignore($"could not download or read the UniProt ptmlist: {exception.Message}");
+                return;
+            }
 
-            Assert.That(mods, Is.Not.Empty,
+            Assert.That(modificationCount, Is.GreaterThan(0),
                 "no UniProt modifications were parsed from ptmlist.txt; check the download succeeded and the "
                 + "ptmlist format has not changed");
         }

--- a/Spritz/SpritzTest/SpritzVersionTests.cs
+++ b/Spritz/SpritzTest/SpritzVersionTests.cs
@@ -45,11 +45,34 @@ namespace SpritzTest
         }
 
         /// <summary>
-        /// The installer's Product/@Version and RunnerEngine.CurrentVersion must agree, otherwise a release
-        /// ships an installer labelled with a different version than the application reports. Runs offline.
+        /// RunnerEngine.CurrentVersion is read from the assembly rather than hardcoded, so this guards the
+        /// reflection actually working. If it silently fell back, the GUI would pull a Docker Hub tag like
+        /// "smithlab/spritz:0.0.0" - an image that does not exist - and the failure would surface as a
+        /// confusing docker pull error rather than as a version problem. Runs offline.
         /// </summary>
         [Test]
-        public void InstallerVersionMatchesCompiledVersion()
+        public void CompiledVersionIsReadFromTheAssembly()
+        {
+            Assert.That(RunnerEngine.CurrentVersion, Does.Match(@"^\d+\.\d+\.\d+"),
+                $"CurrentVersion is '{RunnerEngine.CurrentVersion}', which is not a version number; the "
+                + "assembly attribute lookup is probably returning nothing");
+            Assert.That(RunnerEngine.CurrentVersion, Is.Not.EqualTo("0.0.0"),
+                "CurrentVersion fell back to 0.0.0, so neither AssemblyInformationalVersion nor "
+                + "AssemblyVersion was readable; check that Directory.Build.props is being imported");
+        }
+
+        /// <summary>
+        /// The installer's version and RunnerEngine.CurrentVersion must agree, otherwise a release ships an
+        /// installer labelled with a different version than the application reports.
+        ///
+        /// They now agree by construction: both come from the MSBuild Version property, defaulted in
+        /// Directory.Build.props and overridden by /p:Version from the git tag at release. So rather than
+        /// comparing two literals - which is what this did while both were hand-maintained - this asserts
+        /// that the wiring is still in place, i.e. that nobody has hardcoded a version back into Product.wxs.
+        /// Runs offline.
+        /// </summary>
+        [Test]
+        public void InstallerVersionComesFromTheBuildRatherThanALiteral()
         {
             FileInfo productWxs = FindProductWxs();
 
@@ -64,9 +87,31 @@ namespace SpritzTest
                 $"the <Product ...> element in {productWxs.FullName} has no Version attribute: {productLine.Trim()}");
 
             string installerVersion = versionAttribute.Split('=')[1].Trim('"');
-            Assert.That(installerVersion, Is.EqualTo(RunnerEngine.CurrentVersion),
-                $"{productWxs.Name} declares Version={installerVersion} but RunnerEngine.CurrentVersion is "
-                + $"{RunnerEngine.CurrentVersion}; these must be bumped together");
+            Assert.That(installerVersion, Is.EqualTo("$(var.Version)"),
+                $"{productWxs.Name} declares Version={installerVersion} instead of the WiX preprocessor "
+                + "variable $(var.Version). Hardcoding it here reintroduces a second copy of the version that "
+                + "has to be bumped by hand and can drift from the git tag and from RunnerEngine.CurrentVersion");
+        }
+
+        /// <summary>
+        /// The wixproj must actually define the Version preprocessor variable that Product.wxs consumes,
+        /// otherwise the installer build fails on an undefined variable. Checked here because the WiX build
+        /// itself only runs on Windows, so a break in this wiring would otherwise surface late. Runs offline.
+        /// </summary>
+        [Test]
+        public void InstallerProjectDefinesTheVersionPreprocessorVariable()
+        {
+            FileInfo productWxs = FindProductWxs();
+            FileInfo wixproj = new(Path.Combine(productWxs.DirectoryName, "SpritzInstaller.wixproj"));
+            Assert.That(wixproj.Exists, Is.True, $"could not find {wixproj.FullName}");
+
+            string wixprojText = File.ReadAllText(wixproj.FullName);
+            Assert.That(wixprojText, Does.Contain("Version=$(Version)"),
+                $"{wixproj.Name} does not pass the MSBuild Version property through DefineConstants, so "
+                + "$(var.Version) in Product.wxs would be undefined and the installer build would fail");
+            Assert.That(wixprojText, Does.Contain("Directory.Build.props"),
+                $"{wixproj.Name} no longer imports Directory.Build.props, so it would not see the version "
+                + "default and would need its own copy of it");
         }
 
         /// <summary>

--- a/Spritz/SpritzTest/SpritzVersionTests.cs
+++ b/Spritz/SpritzTest/SpritzVersionTests.cs
@@ -7,42 +7,12 @@ namespace SpritzTest
 {
     public class SpritzVersionTests
     {
-        /// <summary>
-        /// Guards against publishing a release newer than the version compiled into the code, i.e. against
-        /// forgetting to bump RunnerEngine.CurrentVersion.
-        ///
-        /// Queries the GitHub releases API, so it is categorised as an external-service test. It cannot pass
-        /// offline, and the unauthenticated GitHub API is rate limited per IP - which CI runners share - so it
-        /// is flaky by nature. It is excluded from the required CI run and executed in a separate
-        /// non-blocking job instead.
-        /// </summary>
-        [Test]
-        [Category("ExternalService")]
-        public void PublishedReleaseIsNotNewerThanCompiledVersion()
-        {
-            SpritzVersion version = new();
-            version.GetVersionNumbersFromWeb();
-
-            // Distinguish "the API told us nothing" from "the versions disagree". Without this, an API
-            // failure is reported as a version mismatch, which sends the reader to the wrong place.
-            Assert.That(version.NewestKnownVersion, Is.Not.Null.And.Not.Empty,
-                "the GitHub releases API returned no tag_name, so this is an external-service failure rather than a version mismatch");
-
-            // SpritzVersion.IsVersionLower(null) throws NullReferenceException rather than returning a
-            // value: GetVersionNumber catches FormatException but not a null input. The no-installer case is
-            // therefore handled here rather than being passed through it.
-            if (version.NewestKnownVersionWithMsi is null)
-            {
-                Assert.That(version.NewestKnownVersion, Is.EqualTo(RunnerEngine.CurrentVersion),
-                    $"newest published release is {version.NewestKnownVersion} and none carries an installer, "
-                    + $"but the code reports {RunnerEngine.CurrentVersion}");
-                return;
-            }
-
-            Assert.That(SpritzVersion.IsVersionLower(version.NewestKnownVersionWithMsi), Is.True,
-                $"newest published release with an installer is {version.NewestKnownVersionWithMsi}, which is newer "
-                + $"than the compiled version {RunnerEngine.CurrentVersion}; bump RunnerEngine.CurrentVersion");
-        }
+        // PublishedReleaseIsNotNewerThanCompiledVersion used to live here. It existed to nag about bumping
+        // RunnerEngine.CurrentVersion before a release, and it is removed because the version now comes from
+        // the git tag, so there is nothing left to forget. Keeping it would have been worse than useless:
+        // after releasing 0.3.14 the development default in Directory.Build.props is still 0.3.13, so every
+        // subsequent pull request would build at 0.3.13, find a newer published release, and fail until
+        // someone bumped the default - reintroducing exactly the manual version chore this change removes.
 
         /// <summary>
         /// RunnerEngine.CurrentVersion is read from the assembly rather than hardcoded, so this guards the


### PR DESCRIPTION
🤖 The version lived in three hand-maintained places that had to be kept in step: `RunnerEngine.CurrentVersion`,
`Product.wxs`, and the git tag. The tag matters because `release.yml` pushes the container as
`smithlab/spritz:$(git describe --tags)` while `RunnerEngine.cs:52` pulls `smithlab/spritz:{CurrentVersion}` -
so if those drift, **the application pulls an image that does not exist**.

`release.yml` already passed `/p:Version` from the tag to the solution and installer builds - but nothing read
it, because both versions were literals. The plumbing was there and simply not connected. This connects it.

| | before | after |
|---|---|---|
| `RunnerEngine.CurrentVersion` | `"0.3.13"` literal | read from `AssemblyInformationalVersion` |
| `Product.wxs` | `Version="0.3.13"` literal | `Version="$(var.Version)"` |
| default | edited by hand in 2 files | `Directory.Build.props`, one place |
| release | edited by hand, then tagged | `git tag 0.3.14` and nothing else |

A command-line property always beats `Directory.Build.props`, so `/p:Version` from the tag wins at release.
The wixproj imports the props file explicitly, because an old-style project does not import
`Microsoft.Common.props` and would otherwise need a second copy of the default.

**A hole this would otherwise have opened:** the `dockerrelease` job built SpritzCMD *without* `/p:Version`, so
the published image would have reported the development default while being tagged with the release version.
`CurrentVersion` is written into the config the container consumes, so that matters. Fixed here.

## Test changes

**Removed `PublishedReleaseIsNotNewerThanCompiledVersion`.** It existed to nag about bumping the version before
a release; with the tag driving everything there is nothing left to forget. Keeping it would have been worse
than redundant - after releasing 0.3.14 the development default is still 0.3.13, so every later pull request
would build at 0.3.13, find a newer published release, and fail until someone bumped the default. That is the
same manual chore this PR removes, reappearing somewhere else. A comment in the file records why, so it does
not get re-added.

**Added three tests on `GenerateCommandsDry`**, which is where `CurrentVersion` is actually consumed and which
had no coverage. They assert the published image is requested at the compiled version and pulled, and they pin
the two escape hatches that make local development work - previously undocumented behaviour of two bare
conditionals:

* an image name that already carries a tag is used verbatim, with no version appended
* a name not containing `smithlab` is not pulled, so a locally built image is not replaced by the registry's

Confirmed these bite rather than passing vacuously: making the version always append fails 1 test, making it
always pull fails 2, unmutated passes 6 of 6.

**Also kept `CompiledVersionIsReadFromTheAssembly`** - a silent fallback would make the GUI pull a nonexistent
`smithlab/spritz:0.0.0` - and two tests that the wiring is intact (that `Product.wxs` still defers to the
preprocessor variable, and that the wixproj still defines it and imports the props file).

## Absorbs #259

#259 made three changes; one is moot here because this PR deletes the test it modified. The other two are
brought across so #259 can be closed:

* **`GetVersionNumbersFromWeb` no longer throws `NullReferenceException`** when the GitHub API answers without
  a `tag_name`, as it does on a rate limit. This is a product fix: the GUI calls it at startup and
  `MainWindow.xaml.cs:167` already guards on null, so the update prompt is quietly skipped instead of the user
  seeing *"Could not get newest version from web: Object reference not set to an instance of an object"*.
* **The UniProt ptmlist test skips rather than fails** when the download is unreachable. That matters more
  after this PR, not less: with the version test gone it is the only external-service test left.

One limit worth knowing: that catch cannot intercept a *missing dependency assembly*, because it surfaces while
the method is being JIT-compiled, before the body runs.

## Verification

`RunnerEngine.CurrentVersion`, compiled through a referencing project:

| build | reports |
|---|---|
| default | `0.3.13` |
| `/p:Version=0.3.14` | `0.3.14` |
| `/p:Version=9.9.9` | `9.9.9` |

The WiX preprocessor value `Product.wxs` will see, via `dotnet msbuild -getProperty:DefineConstants`:

| build | `DefineConstants` |
|---|---|
| Release, default | `Version=0.3.13` |
| Release, `/p:Version=0.3.14` | `Version=0.3.14` |
| Debug | `Debug;Version=0.3.13` |

Offline tests pass, 6 of 6. Pointing the version URL at a 404 endpoint - the same payload shape as a rate limit
- no longer throws.

**Not verified locally:** the WiX compile is Windows-only, so only the MSBuild property flow feeding it could be
checked here; the installer build in CI is the real check. (Making that class of change locally testable is the
motivation for the WiX v3 to v5 migration, tracked separately.)

Local development is unaffected: the Dockerfile contains no version, a local image is tagged by whatever you
pass to `docker build`, and `spritz:dev` skips both version substitution and the pull, as the new tests now pin.