### PR TITLE
Fix the release action reference, check all references in CI, and bump the dev default to 0.3.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,41 @@ on:
   workflow_dispatch:
 
 jobs:
+  # release.yml only ever runs on a tag, so nothing here exercises the actions it references. A bad
+  # version bump there stayed invisible until a release was cut, and then failed the job at "Set up
+  # job" before a single step ran. This resolves every `uses:` reference in every workflow against
+  # the API, so an unresolvable one fails a pull request instead of a release.
+  action-refs:
+    name: Verify workflow action references resolve
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@v7
+    - name: Resolve every `uses:` reference
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -uo pipefail
+        # Anchored to the start of a line so this step does not match the pattern in its own source.
+        grep -rhoE '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*[^[:space:]]+' .github/workflows/*.yml \
+          | sed -E 's/^.*uses:[[:space:]]*//' | sort -u > refs.txt
+        failed=0
+        while read -r ref; do
+          [ -z "$ref" ] && continue
+          case "$ref" in ./*|docker://*) echo "skip $ref"; continue;; esac
+          repo="${ref%@*}"
+          rev="${ref##*@}"
+          if gh api "repos/$repo/git/ref/tags/$rev" >/dev/null 2>&1 \
+            || gh api "repos/$repo/git/ref/heads/$rev" >/dev/null 2>&1 \
+            || gh api "repos/$repo/commits/$rev" >/dev/null 2>&1; then
+            echo "ok   $ref"
+          else
+            echo "::error::unresolvable action reference: $ref"
+            failed=1
+          fi
+        done < refs.txt
+        exit $failed
+
   builds:
     runs-on: windows-latest
     timeout-minutes: 15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,14 +53,14 @@ jobs:
           directory: ./
 
       - name: Upload SpritzCMD
-        uses: svenstaro/upload-release-action@v2.11.5
+        uses: svenstaro/upload-release-action@2.11.5
         with:
           repo_token: ${{ secrets.UPLOAD_TOKEN }}
           file: SpritzCMD.zip
           tag: ${{ github.ref }}
 
       - name: Upload Installer
-        uses: svenstaro/upload-release-action@v2.11.5
+        uses: svenstaro/upload-release-action@2.11.5
         with:
           repo_token: ${{ secrets.UPLOAD_TOKEN }}
           file: Spritz/SpritzInstaller/bin/Release/Spritz.msi

--- a/Spritz/Directory.Build.props
+++ b/Spritz/Directory.Build.props
@@ -4,6 +4,6 @@
          and a command-line property always wins over this default, so tagging is the only thing
          that decides what a release reports. This value is what local and CI builds use, and so
          also the Docker Hub tag a development build of the GUI pulls by default. -->
-    <Version Condition=" '$(Version)' == '' ">0.3.13</Version>
+    <Version Condition=" '$(Version)' == '' ">0.3.14</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Cutting 0.3.14 failed. This fixes it and prevents the class of failure.

## 1. The release is broken by an unresolvable action reference

`githubrelease` failed at **"Set up job"**, before a single step ran:

```
Unable to resolve action `svenstaro/upload-release-action@v2.11.5`, unable to find version `v2.11.5`
```

That action tags releases **without** a leading `v` — `2.11.5` exists, `v2.11.5` is a 404 — and #245
bumped it to the prefixed form. `release.yml` only runs on a tag, so nothing exercised it until a
release was cut. `svenstaro/upload-release-action` and `thedoctor0/zip-release` are the only two
references not shared with `build.yml`, and they are exactly the two that were never checked.

**Current state of 0.3.14:** the `dockerrelease` job in the same run succeeded, so
`smithlab/spritz:0.3.14` is published on Docker Hub. No GitHub release object was created, so no
`.msi` and no `SpritzCMD.zip`, and the GUI's update check sees nothing. Nobody is affected; the tag
needs re-cutting once this merges.

## 2. A guard so it cannot recur

New `action-refs` job in `build.yml` resolves every `uses:` reference in every workflow against the
API. An unresolvable reference now fails a pull request instead of a release.

The grep is anchored to the start of a line so the step does not match the pattern in its own source
— it did on the first attempt, and tried to resolve fragments of its own script.

Verified both directions locally:

| | result |
|---|---|
| with the fix | all six references resolve, exit 0 |
| with `v2.11.5` reintroduced | `::error::unresolvable action reference`, exit 1 |

## 3. Development default to 0.3.14

`Directory.Build.props` holds the version local and CI builds use; `release.yml` overrides it with
`/p:Version` from the git tag, so it never decides what a release reports. It does decide what a
development build of the GUI pulls from Docker Hub, so leaving it at 0.3.13 would mean development
runs testing against the previous image. Verified `RunnerEngine.CurrentVersion` follows it, reporting
`0.3.14`; offline tests pass 6 of 6.

## After merging

Delete and re-create the tag so the release runs against the fixed workflow:

```bash
git tag -d 0.3.14 && git push origin :refs/tags/0.3.14
git tag 0.3.14 && git push origin 0.3.14
```

`dockerrelease` will re-push the same image tag, which is harmless.