### PR TITLE
Upload release assets with the built-in token instead of a personal one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,14 +55,14 @@ jobs:
       - name: Upload SpritzCMD
         uses: svenstaro/upload-release-action@2.11.5
         with:
-          repo_token: ${{ secrets.UPLOAD_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: SpritzCMD.zip
           tag: ${{ github.ref }}
 
       - name: Upload Installer
         uses: svenstaro/upload-release-action@2.11.5
         with:
-          repo_token: ${{ secrets.UPLOAD_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: Spritz/SpritzInstaller/bin/Release/Spritz.msi
           tag: ${{ github.ref }}
 


### PR DESCRIPTION
The re-cut 0.3.14 release got much further - the action-reference fix worked - but failed at
**Upload SpritzCMD**:

```
Bad credentials - https://docs.github.com/rest
```

Both upload steps authenticate with `secrets.UPLOAD_TOKEN`, a personal access token last set on
**2025-01-16**. It has since expired.

`secrets.GITHUB_TOKEN` does the same job, never expires, and needs no maintenance. This repository's
`default_workflow_permissions` is already `write`, so no `permissions:` block is required.

## What did succeed

Everything up to the upload, which is worth recording because most of it had never run before:

| step | result |
|---|---|
| Set up job | pass - the action-reference fix worked |
| Build | pass |
| Test | pass - unfiltered, so the ExternalService tests ran and did not flake |
| **Build Installer** | **pass** - first real exercise of the WiX `$(var.Version)` wiring in a release |
| Create archive | pass |
| Upload SpritzCMD | **fail** - expired token |

`dockerrelease` succeeded again, so `smithlab/spritz:0.3.14` is published. There is still no GitHub
release object, so no `.msi` or `SpritzCMD.zip`, and the GUI's update check sees nothing.

## After merging

Re-cut the tag once more so the release runs against the fixed workflow:

```bash
git tag -d 0.3.14 && git push origin :refs/tags/0.3.14
git tag 0.3.14 && git push origin 0.3.14
```

## Alternative, if you would rather not re-tag

Regenerate the `UPLOAD_TOKEN` secret and re-run the failed job on the existing tag. That works
without merging this, but leaves a PAT to renew again in a year. Switching to the built-in token
removes that upkeep permanently, which is why it is proposed as the fix.