### PR TITLE
Add a cross-platform Avalonia GUI, built and released for macOS and Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,6 +176,33 @@ jobs:
       run: cd Spritz/workflow/tests && python -m pytest -v
 
 
+  # The Avalonia GUI is the only part of Spritz meant to run on more than Windows, so it is built and
+  # tested on all three, and deliberately by project path rather than through Spritz.sln. The solution
+  # defines only x64 and x86 platforms and CI builds it with /p:Platform=x64, while this project sets no
+  # PlatformTarget on purpose - adding it to that solution would map it to a platform it does not want.
+  # Its tests use Avalonia's headless platform, so no display is needed on any runner.
+  gui-crossplatform:
+    name: Avalonia GUI (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+    - uses: actions/checkout@v7
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Build
+      run: dotnet build --configuration Release Spritz/SpritzGUI.Avalonia/SpritzGUI.Avalonia.csproj
+
+    - name: Test
+      run: dotnet test --configuration Release --verbosity normal Spritz/SpritzGUI.Avalonia.Tests/SpritzGUI.Avalonia.Tests.csproj
+
+
   dockerbuild:
     runs-on: ubuntu-latest
     timeout-minutes: 90

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,89 @@ jobs:
           tag: ${{ github.ref }}
 
 
+  # Self-contained desktop builds of the Avalonia GUI, added alongside the Windows installer rather
+  # than replacing it. Published per runner so each platform's binaries are produced natively: the
+  # macOS .app bundle in particular needs the executable bit and bundle layout that a native runner
+  # gives, and ditto rather than zip to preserve them.
+  #
+  # These are a preview. The WPF installer above remains the supported Windows download.
+  desktop:
+    name: Desktop GUI (${{ matrix.rid }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: windows-latest, rid: win-x64,   archive: zip }
+          - { os: ubuntu-latest,  rid: linux-x64, archive: targz }
+          - { os: macos-latest,   rid: osx-arm64, archive: app }
+          - { os: macos-latest,   rid: osx-x64,   archive: app }
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: 10.0.x
+
+    # Same tag-driven version as everything else, so the GUI reports what the release says.
+    - name: Publish
+      shell: bash
+      run: |
+        version=$(git describe --tags)
+        dotnet publish Spritz/SpritzGUI.Avalonia/SpritzGUI.Avalonia.csproj \
+          --configuration Release --runtime ${{ matrix.rid }} --self-contained true \
+          /p:Version=${version} --output publish/${{ matrix.rid }}
+
+    - name: Assemble macOS .app bundle
+      if: matrix.archive == 'app'
+      shell: bash
+      run: |
+        version=$(git describe --tags)
+        app="Spritz.app"
+        mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources"
+        cp -R publish/${{ matrix.rid }}/. "$app/Contents/MacOS/"
+        chmod +x "$app/Contents/MacOS/Spritz"
+        cat > "$app/Contents/Info.plist" <<PLIST
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+          <key>CFBundleName</key><string>Spritz</string>
+          <key>CFBundleDisplayName</key><string>Spritz</string>
+          <key>CFBundleIdentifier</key><string>edu.wisc.smithchem.spritz</string>
+          <key>CFBundleExecutable</key><string>Spritz</string>
+          <key>CFBundlePackageType</key><string>APPL</string>
+          <key>CFBundleShortVersionString</key><string>${version}</string>
+          <key>CFBundleVersion</key><string>${version}</string>
+          <key>LSMinimumSystemVersion</key><string>11.0</string>
+          <key>NSHighResolutionCapable</key><true/>
+        </dict>
+        </plist>
+        PLIST
+        # ditto, not zip: it preserves the bundle's structure and permissions.
+        ditto -c -k --keepParent "$app" "Spritz-${{ matrix.rid }}.app.zip"
+
+    - name: Archive (zip)
+      if: matrix.archive == 'zip'
+      shell: bash
+      run: cd publish/${{ matrix.rid }} && 7z a ../../Spritz-${{ matrix.rid }}.zip .
+
+    - name: Archive (tar.gz)
+      if: matrix.archive == 'targz'
+      shell: bash
+      run: tar -czf Spritz-${{ matrix.rid }}.tar.gz -C publish/${{ matrix.rid }} .
+
+    - name: Upload
+      uses: svenstaro/upload-release-action@2.11.5
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: Spritz-${{ matrix.rid }}.*
+        file_glob: true
+        tag: ${{ github.ref }}
+
   dockerrelease:
     runs-on: ubuntu-latest
     timeout-minutes: 90

--- a/Spritz/SpritzGUI.Avalonia.Tests/MainWindowTests.cs
+++ b/Spritz/SpritzGUI.Avalonia.Tests/MainWindowTests.cs
@@ -1,0 +1,127 @@
+using System.Linq;
+using Avalonia;
+using Avalonia.Headless;
+using Avalonia.Headless.NUnit;
+using NUnit.Framework;
+using Spritz.Avalonia;
+using Spritz.Avalonia.Services;
+using Spritz.Avalonia.ViewModels;
+using Spritz.Avalonia.Views;
+
+[assembly: AvaloniaTestApplication(typeof(SpritzTest.Avalonia.TestAppBuilder))]
+
+namespace SpritzTest.Avalonia;
+
+/// <summary>Boots the real App on Avalonia's headless platform, so no display is needed.</summary>
+public static class TestAppBuilder
+{
+    public static AppBuilder BuildAvaloniaApp() => AppBuilder.Configure<App>()
+        .UseHeadless(new AvaloniaHeadlessPlatformOptions());
+}
+
+/// <summary>
+/// The WPF GUI cannot be tested at all - its logic lives in MainWindow.xaml.cs behind a Window. These
+/// tests exist to show what the port buys: the window can be constructed without a display, and the
+/// command construction that used to be inline is now reachable directly.
+/// </summary>
+public class MainWindowTests
+{
+    /// <summary>
+    /// Constructs the real window with the real view model. This is what a plain build cannot prove:
+    /// that the XAML resolves at runtime, including the DataGrid theme brought in by App.axaml.
+    /// </summary>
+    [AvaloniaTest]
+    public void MainWindowBuildsWithoutADisplay()
+    {
+        var window = new MainWindow { DataContext = new MainWindowViewModel() };
+        window.Show();
+
+        Assert.That(window.IsVisible, Is.True);
+        Assert.That(window.Title, Is.EqualTo("Spritz"));
+    }
+}
+
+/// <summary>
+/// Docker argument construction, which the WPF GUI builds as one shell string inside a click handler.
+/// </summary>
+public class DockerArgumentsTests
+{
+    [Test]
+    public void PublishedImageIsPulledAndTaggedWithTheCompiledVersion()
+    {
+        Assert.That(DockerArguments.ShouldPull("smithlab/spritz"), Is.True);
+        Assert.That(DockerArguments.ImageWithVersion("smithlab/spritz"),
+            Is.EqualTo($"smithlab/spritz:{SpritzBackend.RunnerEngine.CurrentVersion}"));
+    }
+
+    [Test]
+    public void ExplicitTagIsUsedVerbatim()
+    {
+        Assert.That(DockerArguments.ImageWithVersion("spritz:dev"), Is.EqualTo("spritz:dev"),
+            "a name that already carries a tag must not have the version appended");
+    }
+
+    [Test]
+    public void LocalImageIsNotPulled()
+    {
+        Assert.That(DockerArguments.ShouldPull("spritz:dev"), Is.False);
+        Assert.That(DockerArguments.ShouldPull("spritz"), Is.False);
+    }
+
+    /// <summary>
+    /// The heuristic the WPF code uses is dockerImageName.Contains("smithlab"), which also matches a
+    /// local image called "smithlab-test" and would pull over it. This asserts the stricter prefix.
+    /// </summary>
+    [Test]
+    public void NameThatMerelyContainsSmithlabIsNotTreatedAsPublished()
+    {
+        Assert.That(DockerArguments.ShouldPull("smithlab-test"), Is.False);
+        Assert.That(DockerArguments.ShouldPull("my-smithlab/spritz"), Is.False);
+    }
+
+    /// <summary>
+    /// The point of the port's process handling: paths are separate arguments, so a space in one
+    /// cannot split it. The WPF version interpolates paths into a shell string inside triple quotes.
+    /// </summary>
+    [Test]
+    public void PathsWithSpacesSurviveAsSingleArguments()
+    {
+        var arguments = DockerArguments.Run(
+            "smithlab/spritz", "spritz-test",
+            "/home/a b/analysis", "/home/a b/resources",
+            new[] { "dotnet", "SpritzCMD.dll" });
+
+        Assert.That(arguments, Has.Member("/home/a b/analysis:/app/spritz/results/"));
+        Assert.That(arguments, Has.Member("/home/a b/resources:/app/spritz/resources"));
+        Assert.That(arguments.Count(a => a == "-v"), Is.EqualTo(2));
+        Assert.That(arguments.Any(a => a.Contains('"')), Is.False,
+            "no argument should need quoting, because no shell ever parses these");
+    }
+
+    [Test]
+    public void RunNamesTheContainerSoItCanBeStopped()
+    {
+        var arguments = DockerArguments.Run(
+            "smithlab/spritz", "spritz-abc", "/analysis", "/resources", new[] { "dotnet" });
+
+        int nameIndex = arguments.ToList().IndexOf("--name");
+        Assert.That(nameIndex, Is.GreaterThanOrEqualTo(0));
+        Assert.That(arguments[nameIndex + 1], Is.EqualTo("spritz-abc"));
+    }
+}
+
+public class DockerSystemInfoTests
+{
+    [Test]
+    public void TotalMemoryIsReadFromDockerSystemInfo()
+    {
+        const string info = "Server:\n Containers: 0\n CPUs: 10\n Total Memory: 7.653GiB\n Name: docker-desktop\n";
+        Assert.That(MainWindowViewModel.ParseTotalMemoryGb(info), Is.EqualTo(7.653 * 1.07374).Within(0.001));
+    }
+
+    [Test]
+    public void MissingMemoryLineReportsZeroRatherThanThrowing()
+    {
+        Assert.That(MainWindowViewModel.ParseTotalMemoryGb("Cannot connect to the Docker daemon"), Is.EqualTo(0));
+    }
+}

--- a/Spritz/SpritzGUI.Avalonia.Tests/SpritzGUI.Avalonia.Tests.csproj
+++ b/Spritz/SpritzGUI.Avalonia.Tests/SpritzGUI.Avalonia.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Avalonia.Headless.NUnit" Version="12.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SpritzGUI.Avalonia\SpritzGUI.Avalonia.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Spritz/SpritzGUI.Avalonia.Tests/ViewModelBehaviourTests.cs
+++ b/Spritz/SpritzGUI.Avalonia.Tests/ViewModelBehaviourTests.cs
@@ -194,10 +194,13 @@ public class FastqEntryTests
     [Test]
     public void TheOutputFolderDefaultsToWhereTheFastqsAre()
     {
+        // Derive both sides from the same path so this does not depend on the separator, which is what
+        // it did before and why it passed on Linux and macOS but not on Windows.
+        string fastq = Path.Combine(Path.GetTempPath(), "reads", "sample_1.fastq");
         var viewModel = new MainWindowViewModel();
-        viewModel.AddFastqFiles(new[] { Path.Combine("/data", "reads", "sample_1.fastq") });
+        viewModel.AddFastqFiles(new[] { fastq });
 
-        Assert.That(viewModel.OutputFolder, Is.EqualTo(Path.Combine("/data", "reads")));
+        Assert.That(viewModel.OutputFolder, Is.EqualTo(Path.GetDirectoryName(fastq)));
     }
 
     [Test]

--- a/Spritz/SpritzGUI.Avalonia.Tests/ViewModelBehaviourTests.cs
+++ b/Spritz/SpritzGUI.Avalonia.Tests/ViewModelBehaviourTests.cs
@@ -1,0 +1,247 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using Spritz.Avalonia.ViewModels;
+
+namespace SpritzTest.Avalonia;
+
+/// <summary>
+/// Behaviour tests modelled on the patterns in MetaMorpheus's Test/GuiTests suite, which the first
+/// pass here missed. Those 299 tests consistently cover four things this file now covers too:
+/// that property changes raise notifications, that commands guard their preconditions, that
+/// constructors establish sensible defaults, and that bad input is rejected rather than absorbed.
+///
+/// Without the notification tests in particular, a binding can silently stop updating and nothing
+/// fails - the window just stops reflecting reality.
+/// </summary>
+public class ViewModelNotificationTests
+{
+    /// <summary>Collects the property names a view model reports as changed.</summary>
+    private static List<string> RecordChanges(INotifyPropertyChanged source)
+    {
+        var changed = new List<string>();
+        source.PropertyChanged += (_, e) => changed.Add(e.PropertyName);
+        return changed;
+    }
+
+    [Test]
+    public void EditableStateRaisesPropertyChanged()
+    {
+        var viewModel = new MainWindowViewModel();
+        var changed = RecordChanges(viewModel);
+
+        viewModel.SraAccession = "SRR13737862";
+        viewModel.OutputFolder = "/tmp/analysis";
+        viewModel.DockerImage = "spritz:dev";
+
+        Assert.That(changed, Does.Contain(nameof(MainWindowViewModel.SraAccession)));
+        Assert.That(changed, Does.Contain(nameof(MainWindowViewModel.OutputFolder)));
+        Assert.That(changed, Does.Contain(nameof(MainWindowViewModel.DockerImage)));
+    }
+
+    [Test]
+    public void SettingAPropertyToItsCurrentValueRaisesNothing()
+    {
+        var viewModel = new MainWindowViewModel { OutputFolder = "/tmp/analysis" };
+        var changed = RecordChanges(viewModel);
+
+        viewModel.OutputFolder = "/tmp/analysis";
+
+        Assert.That(changed, Is.Empty, "an unchanged value should not notify, or the UI churns");
+    }
+
+    [Test]
+    public void RunStateRaisesPropertyChangedSoButtonsCanEnableAndDisable()
+    {
+        var viewModel = new MainWindowViewModel();
+        var changed = RecordChanges(viewModel);
+
+        viewModel.IsRunning = true;
+
+        Assert.That(changed, Does.Contain(nameof(MainWindowViewModel.IsRunning)),
+            "the Run and Cancel buttons bind to IsRunning, so it has to notify");
+    }
+}
+
+public class SraEntryTests
+{
+    [TestCase("SRR13737862")]
+    [TestCase("ERR1234567")]
+    [TestCase("srr13737862")]
+    public void RecognisableAccessionsAreAccepted(string accession)
+    {
+        var viewModel = new MainWindowViewModel { SraAccession = accession };
+        viewModel.AddPairedEndSraCommand.Execute(null);
+
+        Assert.That(viewModel.Sras.Select(s => s.Name), Does.Contain(accession));
+    }
+
+    [TestCase("not-an-accession")]
+    [TestCase("12345")]
+    [TestCase("")]
+    public void UnrecognisableAccessionsAreRejectedWithAnExplanation(string accession)
+    {
+        var viewModel = new MainWindowViewModel { SraAccession = accession };
+        viewModel.AddPairedEndSraCommand.Execute(null);
+
+        Assert.That(viewModel.Sras, Is.Empty);
+        if (accession.Length > 0)
+        {
+            Assert.That(viewModel.Information, Does.Contain(accession),
+                "a rejected accession should be named, so the user knows which one was wrong");
+        }
+    }
+
+    [Test]
+    public void PairedAndSingleEndAreRecordedDistinctly()
+    {
+        var viewModel = new MainWindowViewModel { SraAccession = "SRR111" };
+        viewModel.AddPairedEndSraCommand.Execute(null);
+        viewModel.SraAccession = "SRR222";
+        viewModel.AddSingleEndSraCommand.Execute(null);
+
+        Assert.That(viewModel.Sras.Single(s => s.Name == "SRR111").IsPairedEnd, Is.True);
+        Assert.That(viewModel.Sras.Single(s => s.Name == "SRR222").IsPairedEnd, Is.False);
+    }
+
+    [Test]
+    public void TheSameAccessionIsNotAddedTwice()
+    {
+        var viewModel = new MainWindowViewModel { SraAccession = "SRR13737862" };
+        viewModel.AddPairedEndSraCommand.Execute(null);
+        viewModel.SraAccession = "SRR13737862";
+        viewModel.AddPairedEndSraCommand.Execute(null);
+
+        Assert.That(viewModel.Sras, Has.Count.EqualTo(1),
+            "adding a duplicate accession would make the pipeline download it twice");
+    }
+
+    [Test]
+    public void AddingClearsTheEntryBoxSoTheNextOneCanBeTyped()
+    {
+        var viewModel = new MainWindowViewModel { SraAccession = "SRR13737862" };
+        viewModel.AddPairedEndSraCommand.Execute(null);
+
+        Assert.That(viewModel.SraAccession, Is.Empty);
+    }
+
+    [Test]
+    public void ClearRemovesEverything()
+    {
+        var viewModel = new MainWindowViewModel { SraAccession = "SRR1" };
+        viewModel.AddPairedEndSraCommand.Execute(null);
+
+        viewModel.ClearSrasCommand.Execute(null);
+
+        Assert.That(viewModel.Sras, Is.Empty);
+    }
+}
+
+public class FastqEntryTests
+{
+    /// <summary>
+    /// Mate-pair detection reads the _1 and _2 suffixes off the filename. Getting it wrong silently
+    /// mispairs the reads, which is the sort of thing that produces a plausible but wrong result, so
+    /// it is worth pinning even though it looks trivial.
+    /// </summary>
+    [Test]
+    public void MatePairIsReadFromTheFilenameSuffix()
+    {
+        var viewModel = new MainWindowViewModel();
+        viewModel.AddFastqFiles(new[] { "/data/TK12_1.fastq", "/data/TK12_2.fastq" });
+
+        Assert.That(viewModel.Fastqs.Single(f => f.FileName == "TK12_1").MatePair, Is.EqualTo("1"));
+        Assert.That(viewModel.Fastqs.Single(f => f.FileName == "TK12_2").MatePair, Is.EqualTo("2"));
+    }
+
+    [Test]
+    public void GzippedFastqsKeepTheirLogicalName()
+    {
+        var viewModel = new MainWindowViewModel();
+        viewModel.AddFastqFiles(new[] { "/data/sample_1.fastq.gz" });
+
+        Assert.That(viewModel.Fastqs, Has.Count.EqualTo(1));
+        Assert.That(viewModel.Fastqs[0].FileName, Is.EqualTo("sample_1"),
+            "both extensions should come off, otherwise the name carries .fastq");
+    }
+
+    [TestCase("/data/notes.txt")]
+    [TestCase("/data/reads.bam")]
+    public void NonFastqFilesAreIgnored(string path)
+    {
+        var viewModel = new MainWindowViewModel();
+        viewModel.AddFastqFiles(new[] { path });
+
+        Assert.That(viewModel.Fastqs, Is.Empty);
+    }
+
+    [Test]
+    public void TheSameFileIsNotAddedTwice()
+    {
+        var viewModel = new MainWindowViewModel();
+        viewModel.AddFastqFiles(new[] { "/data/sample_1.fastq" });
+        viewModel.AddFastqFiles(new[] { "/data/sample_1.fastq" });
+
+        Assert.That(viewModel.Fastqs, Has.Count.EqualTo(1));
+    }
+
+    /// <summary>
+    /// The analysis directory defaults to where the FASTQs are, because the pipeline expects them
+    /// under it - #237's reporter hit trouble partly through a mismatch here.
+    /// </summary>
+    [Test]
+    public void TheOutputFolderDefaultsToWhereTheFastqsAre()
+    {
+        var viewModel = new MainWindowViewModel();
+        viewModel.AddFastqFiles(new[] { Path.Combine("/data", "reads", "sample_1.fastq") });
+
+        Assert.That(viewModel.OutputFolder, Is.EqualTo(Path.Combine("/data", "reads")));
+    }
+
+    [Test]
+    public void AnExistingOutputFolderIsNotOverwritten()
+    {
+        var viewModel = new MainWindowViewModel { OutputFolder = "/chosen/by/the/user" };
+        viewModel.AddFastqFiles(new[] { "/data/sample_1.fastq" });
+
+        Assert.That(viewModel.OutputFolder, Is.EqualTo("/chosen/by/the/user"),
+            "adding files must not silently move an analysis directory the user picked");
+    }
+}
+
+public class RunPreconditionTests
+{
+    [Test]
+    public void RunIsRefusedWithNoWorkflow()
+    {
+        var viewModel = new MainWindowViewModel { OutputFolder = "/tmp/out" };
+
+        Assert.That(viewModel.CanRun, Is.False, "there is no workflow to run yet");
+        viewModel.RunWorkflowCommand.Execute(null);
+        Assert.That(viewModel.Information, Does.Contain("workflow"),
+            "refusing should say why, not fail silently");
+    }
+
+    [Test]
+    public void RunIsRefusedWithNoAnalysisDirectory()
+    {
+        var viewModel = new MainWindowViewModel();
+
+        Assert.That(viewModel.CanRun, Is.False);
+    }
+
+    [Test]
+    public void ADefaultDockerImageIsSetSoTheGuiWorksUnconfigured()
+    {
+        Assert.That(new MainWindowViewModel().DockerImage, Is.EqualTo("smithlab/spritz"));
+    }
+
+    [Test]
+    public void DockerStatusStartsAsAnInProgressMessageRatherThanBlank()
+    {
+        Assert.That(new MainWindowViewModel().DockerStatus, Is.Not.Empty,
+            "a blank status bar at startup looks like a broken window");
+    }
+}

--- a/Spritz/SpritzGUI.Avalonia/App.axaml
+++ b/Spritz/SpritzGUI.Avalonia/App.axaml
@@ -1,0 +1,9 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Spritz.Avalonia.App"
+             RequestedThemeVariant="Default">
+  <Application.Styles>
+    <FluentTheme />
+    <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml" />
+  </Application.Styles>
+</Application>

--- a/Spritz/SpritzGUI.Avalonia/App.axaml.cs
+++ b/Spritz/SpritzGUI.Avalonia/App.axaml.cs
@@ -1,0 +1,21 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+using Spritz.Avalonia.ViewModels;
+using Spritz.Avalonia.Views;
+
+namespace Spritz.Avalonia;
+
+public partial class App : Application
+{
+    public override void Initialize() => AvaloniaXamlLoader.Load(this);
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.MainWindow = new MainWindow { DataContext = new MainWindowViewModel() };
+        }
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/Spritz/SpritzGUI.Avalonia/Program.cs
+++ b/Spritz/SpritzGUI.Avalonia/Program.cs
@@ -1,0 +1,15 @@
+using Avalonia;
+
+namespace Spritz.Avalonia;
+
+internal static class Program
+{
+    // Avalonia needs a plain Main; nothing here is platform specific.
+    [System.STAThread]
+    public static void Main(string[] args) => BuildAvaloniaApp()
+        .StartWithClassicDesktopLifetime(args);
+
+    public static AppBuilder BuildAvaloniaApp() => AppBuilder.Configure<App>()
+        .UsePlatformDetect()
+        .LogToTrace();
+}

--- a/Spritz/SpritzGUI.Avalonia/Services/DockerArguments.cs
+++ b/Spritz/SpritzGUI.Avalonia/Services/DockerArguments.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using SpritzBackend;
+
+namespace Spritz.Avalonia.Services;
+
+/// <summary>
+/// Builds the docker argument list, as a list rather than a shell string.
+///
+/// This is the argument-list counterpart of RunnerEngine.GenerateCommandsDry, which returns
+/// `docker pull ...; docker run ...; docker stop ...` as one string for a shell to split. Keeping it
+/// here rather than in SpritzBackend for now, so the draft does not change behaviour the Windows GUI
+/// depends on; it belongs in SpritzBackend once both front ends can use it.
+/// </summary>
+public static class DockerArguments
+{
+    /// <summary>Whether this image name refers to the published image and so should be pulled first.</summary>
+    public static bool ShouldPull(string dockerImageName) =>
+        dockerImageName.StartsWith("smithlab/", StringComparison.Ordinal);
+
+    /// <summary>The image reference, with the compiled version appended when no tag was given.</summary>
+    public static string ImageWithVersion(string dockerImageName) =>
+        dockerImageName.Contains(':') ? dockerImageName : $"{dockerImageName}:{RunnerEngine.CurrentVersion}";
+
+    public static IReadOnlyList<string> Pull(string dockerImageName) =>
+        new[] { "pull", ImageWithVersion(dockerImageName) };
+
+    /// <summary>
+    /// `docker run` with the analysis and resources directories mounted. The paths go in as
+    /// individual arguments, so a space or a quote in them needs no escaping and cannot split.
+    /// </summary>
+    public static IReadOnlyList<string> Run(
+        string dockerImageName, string containerName, string analysisDirectory,
+        string resourcesDirectory, IEnumerable<string> containerCommand)
+    {
+        var arguments = new List<string>
+        {
+            "run", "--rm", "--user=root",
+            "--name", containerName,
+            "-v", $"{analysisDirectory}:/app/spritz/results/",
+            "-v", $"{resourcesDirectory}:/app/spritz/resources",
+            ImageWithVersion(dockerImageName),
+        };
+        arguments.AddRange(containerCommand);
+        return arguments;
+    }
+
+    /// <summary>The in-container command: conda run, then SpritzCMD with the user's options.</summary>
+    public static IReadOnlyList<string> SpritzCmd(SpritzOptions options)
+    {
+        var arguments = new List<string>
+        {
+            "conda", "run", "--no-capture-output", "--live-stream", "dotnet", "SpritzCMD.dll",
+        };
+        // SpritzOptionStrings builds a single argument string; split on spaces it does not own.
+        foreach (string argument in SpritzOptionStrings.GenerateSpritzCMDArgs(options)
+                     .Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            arguments.Add(argument.Replace("\"\"\"", string.Empty));
+        }
+        return arguments;
+    }
+
+    /// <summary>A readable rendering of a command, for the information pane only.</summary>
+    public static string Describe(IEnumerable<string> arguments) => "docker " + string.Join(" ", arguments);
+}

--- a/Spritz/SpritzGUI.Avalonia/Services/DockerProcessRunner.cs
+++ b/Spritz/SpritzGUI.Avalonia/Services/DockerProcessRunner.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Spritz.Avalonia.Services;
+
+/// <summary>
+/// Runs docker directly, rather than handing a command string to a shell.
+///
+/// The WPF GUI sets proc.StartInfo.FileName = "Powershell.exe" and passes the whole
+/// `docker pull ...; docker run ...; docker stop ...` string as arguments. That only works on
+/// Windows, and it relies on a shell to split and unquote the arguments - which is also why the
+/// existing command interpolates volume paths inside triple quotes. Passing an argument list
+/// instead removes both the platform dependency and the quoting question: no shell ever sees the
+/// path, so spaces and quotes in it are not special.
+/// </summary>
+public sealed class DockerProcessRunner
+{
+    private readonly Action<string> _onOutput;
+
+    public DockerProcessRunner(Action<string> onOutput) => _onOutput = onOutput;
+
+    /// <summary>Whether a docker binary is present and responding, and what it said.</summary>
+    public async Task<(bool Available, string Info)> QuerySystemInfoAsync(CancellationToken token = default)
+    {
+        try
+        {
+            var (exitCode, output) = await CaptureAsync("docker", new[] { "system", "info" }, token);
+            bool available = exitCode == 0 && !string.IsNullOrWhiteSpace(output);
+            return (available, output);
+        }
+        catch (Exception exception)
+        {
+            // A missing binary throws rather than returning a code, and that is the common case for
+            // a user who has not installed Docker, so it is reported rather than thrown onward.
+            return (false, exception.Message);
+        }
+    }
+
+    /// <summary>Streams `docker run` output line by line until the container exits.</summary>
+    public Task<int> RunAsync(IReadOnlyList<string> arguments, CancellationToken token = default) =>
+        StreamAsync("docker", arguments, token);
+
+    /// <summary>Stops a named container. Used on cancel and on window close.</summary>
+    public async Task StopContainerAsync(string containerName, CancellationToken token = default)
+    {
+        if (string.IsNullOrWhiteSpace(containerName))
+        {
+            return;
+        }
+        await CaptureAsync("docker", new[] { "stop", containerName }, token);
+    }
+
+    private async Task<int> StreamAsync(string fileName, IReadOnlyList<string> arguments, CancellationToken token)
+    {
+        using var process = new Process { StartInfo = StartInfo(fileName, arguments) };
+        process.OutputDataReceived += (_, e) => Emit(e.Data);
+        process.ErrorDataReceived += (_, e) => Emit(e.Data);
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        await using (token.Register(() => TryKill(process)))
+        {
+            await process.WaitForExitAsync(CancellationToken.None);
+        }
+        return process.ExitCode;
+    }
+
+    private static async Task<(int ExitCode, string Output)> CaptureAsync(
+        string fileName, IReadOnlyList<string> arguments, CancellationToken token)
+    {
+        using var process = new Process { StartInfo = StartInfo(fileName, arguments) };
+        process.Start();
+        string output = await process.StandardOutput.ReadToEndAsync(token);
+        string error = await process.StandardError.ReadToEndAsync(token);
+        await process.WaitForExitAsync(token);
+        return (process.ExitCode, string.IsNullOrWhiteSpace(output) ? error : output);
+    }
+
+    private static ProcessStartInfo StartInfo(string fileName, IReadOnlyList<string> arguments)
+    {
+        var info = new ProcessStartInfo
+        {
+            FileName = fileName,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+        foreach (string argument in arguments)
+        {
+            info.ArgumentList.Add(argument);
+        }
+        return info;
+    }
+
+    private void Emit(string line)
+    {
+        if (!string.IsNullOrEmpty(line))
+        {
+            _onOutput(line);
+        }
+    }
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // Already gone between the check and the kill; nothing to do.
+        }
+    }
+}

--- a/Spritz/SpritzGUI.Avalonia/SpritzGUI.Avalonia.csproj
+++ b/Spritz/SpritzGUI.Avalonia/SpritzGUI.Avalonia.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+    <AssemblyName>Spritz</AssemblyName>
+    <RootNamespace>Spritz.Avalonia</RootNamespace>
+  </PropertyGroup>
+
+  <!-- The view model and the linked model classes are internal, so the tests need this to see them. -->
+  <ItemGroup>
+    <InternalsVisibleTo Include="SpritzGUI.Avalonia.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="12.1.1" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.1.1" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.1" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="12.1.2" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SpritzBackend\SpritzBackend.csproj" />
+  </ItemGroup>
+
+  <!-- Linked, not copied. These model classes contain no WPF types, so the Windows GUI and this one
+       compile the same source. If they ever gain a UI dependency, this build breaks and says so. -->
+  <ItemGroup>
+    <Compile Include="..\SpritzGUI\DataGrids\*.cs" Link="Models\%(Filename).cs" />
+    <Compile Include="..\SpritzGUI\TreeViews\*.cs" Link="Models\%(Filename).cs" />
+  </ItemGroup>
+
+</Project>

--- a/Spritz/SpritzGUI.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/Spritz/SpritzGUI.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Spritz.Avalonia.Services;
+using SpritzBackend;
+
+namespace Spritz.Avalonia.ViewModels;
+
+/// <summary>
+/// Everything the window does, with no UI types in it.
+///
+/// The WPF version keeps this logic in MainWindow.xaml.cs, so none of it can be tested without a
+/// window. Here the view binds to these properties and commands, which means the run flow, the
+/// docker detection and the argument construction are all reachable from a test.
+/// </summary>
+internal sealed partial class MainWindowViewModel : ObservableObject
+{
+    private static readonly Regex AnsiEscape = new(@"(\[\d+m)", RegexOptions.Compiled);
+
+    private readonly DockerProcessRunner _docker;
+    private CancellationTokenSource _cancellation;
+    private RunnerEngine _runner;
+
+    public ObservableCollection<SRADataGrid> Sras { get; } = new();
+    public ObservableCollection<RNASeqFastqDataGrid> Fastqs { get; } = new();
+    public ObservableCollection<PreRunTask> Workflows { get; } = new();
+
+    [ObservableProperty] private string _sraAccession = string.Empty;
+    [ObservableProperty] private string _dockerImage = "smithlab/spritz";
+    [ObservableProperty] private string _outputFolder = string.Empty;
+    [ObservableProperty] private string _information = string.Empty;
+    [ObservableProperty] private string _dockerStatus = "Checking for Docker...";
+    [ObservableProperty] private bool _isRunning;
+
+    public MainWindowViewModel()
+    {
+        _docker = new DockerProcessRunner(AppendInformation);
+        _ = CheckDockerAsync();
+    }
+
+    /// <summary>
+    /// Reports whether Docker is usable, and how much memory it has. The WPF version does this in
+    /// the constructor with a blocking Dispatcher.Invoke and then a modal dialog; here it is
+    /// asynchronous and surfaces as a status line, so a slow or absent Docker cannot hang startup.
+    /// </summary>
+    private async Task CheckDockerAsync()
+    {
+        var (available, info) = await _docker.QuerySystemInfoAsync();
+        if (!available)
+        {
+            DockerStatus = "Docker is not running or not installed. Install Docker and start it, "
+                + "then restart Spritz.";
+            return;
+        }
+
+        double memoryGb = ParseTotalMemoryGb(info);
+        DockerStatus = memoryGb > 0 && memoryGb < 16
+            ? $"Docker is running, but only {memoryGb:F1} GB is allocated to it. Raise this above 16 GB if you can."
+            : "Docker is running.";
+    }
+
+    /// <summary>Reads "Total Memory: 31.2GiB" out of `docker system info`, in GB.</summary>
+    internal static double ParseTotalMemoryGb(string dockerSystemInfo)
+    {
+        const double gibToGb = 1.07374;
+        string line = dockerSystemInfo
+            .Split('\n')
+            .FirstOrDefault(l => l.TrimStart().StartsWith("Total Memory", StringComparison.OrdinalIgnoreCase));
+        if (line is null || !line.Contains(':'))
+        {
+            return 0;
+        }
+        return double.TryParse(line.Split(':')[1].Replace("GiB", string.Empty).Trim(), out double gib)
+            ? gib * gibToGb
+            : 0;
+    }
+
+    [RelayCommand]
+    private void AddPairedEndSra() => AddSra(isPairedEnd: true);
+
+    [RelayCommand]
+    private void AddSingleEndSra() => AddSra(isPairedEnd: false);
+
+    private void AddSra(bool isPairedEnd)
+    {
+        string accession = SraAccession?.Trim();
+        if (string.IsNullOrEmpty(accession))
+        {
+            return;
+        }
+        if (!accession.StartsWith("SR", StringComparison.OrdinalIgnoreCase)
+            && !accession.StartsWith("ER", StringComparison.OrdinalIgnoreCase))
+        {
+            AppendInformation($"'{accession}' does not look like an SRA accession; expected something like SRR13737862.");
+            return;
+        }
+        if (Sras.Any(s => s.Name == accession))
+        {
+            return;
+        }
+        Sras.Add(new SRADataGrid(accession, isPairedEnd));
+        SraAccession = string.Empty;
+    }
+
+    [RelayCommand]
+    private void ClearSras() => Sras.Clear();
+
+    [RelayCommand]
+    private void ClearFastqs() => Fastqs.Clear();
+
+    /// <summary>Adds FASTQ paths chosen by the view, which owns the file dialog.</summary>
+    public void AddFastqFiles(IEnumerable<string> paths)
+    {
+        foreach (string path in paths.Where(p => p.EndsWith(".fastq") || p.EndsWith(".fastq.gz")))
+        {
+            if (Fastqs.All(f => f.FilePath != path))
+            {
+                Fastqs.Add(new RNASeqFastqDataGrid(path, isPairedEnd: path.Contains("_1") || path.Contains("_2")));
+            }
+        }
+        if (string.IsNullOrEmpty(OutputFolder) && Fastqs.Count > 0)
+        {
+            OutputFolder = Path.GetDirectoryName(Fastqs[0].FilePath) ?? string.Empty;
+        }
+    }
+
+    public bool CanRun => !IsRunning && Workflows.Count > 0 && !string.IsNullOrWhiteSpace(OutputFolder);
+
+    [RelayCommand]
+    private async Task RunWorkflowAsync()
+    {
+        if (Workflows.Count == 0)
+        {
+            AppendInformation("Add a workflow before running.");
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(OutputFolder))
+        {
+            AppendInformation("Choose an analysis directory before running.");
+            return;
+        }
+
+        SpritzOptions options = Workflows.First().options;
+        _runner = new RunnerEngine(new Tuple<string, SpritzOptions>("Workflow 1", options), OutputFolder);
+        _cancellation = new CancellationTokenSource();
+        IsRunning = true;
+
+        try
+        {
+            IReadOnlyList<string> containerCommand = DockerArguments.SpritzCmd(options);
+            IReadOnlyList<string> runArguments = DockerArguments.Run(
+                DockerImage, _runner.SpritzContainerName, _runner.AnalysisDirectory,
+                _runner.ResourcesDirectory, containerCommand);
+
+            if (DockerArguments.ShouldPull(DockerImage))
+            {
+                AppendInformation(DockerArguments.Describe(DockerArguments.Pull(DockerImage)));
+                await _docker.RunAsync(DockerArguments.Pull(DockerImage), _cancellation.Token);
+            }
+
+            AppendInformation(DockerArguments.Describe(runArguments));
+            AppendInformation($"Saving output to {_runner.PathToWorkflow}");
+            AppendInformation(string.Empty);
+
+            int exitCode = await _docker.RunAsync(runArguments, _cancellation.Token);
+            AppendInformation(exitCode == 0
+                ? $"Done. Results are in {options.AnalysisDirectory}"
+                : $"Spritz exited with code {exitCode}. See the output above.");
+        }
+        catch (Exception exception)
+        {
+            AppendInformation($"ERROR: {exception.Message}");
+        }
+        finally
+        {
+            IsRunning = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task CancelAsync()
+    {
+        _cancellation?.Cancel();
+        if (_runner is not null)
+        {
+            await _docker.StopContainerAsync(_runner.SpritzContainerName);
+        }
+    }
+
+    /// <summary>Appends a line to the information pane and to the workflow log on disk.</summary>
+    private void AppendInformation(string line)
+    {
+        string scrubbed = AnsiEscape.Replace(line ?? string.Empty, string.Empty);
+        Information += scrubbed + Environment.NewLine;
+
+        if (_runner is not null && !string.IsNullOrEmpty(_runner.PathToWorkflow))
+        {
+            try
+            {
+                File.AppendAllText(_runner.PathToWorkflow, scrubbed + Environment.NewLine);
+            }
+            catch (IOException)
+            {
+                // The pane is the primary output; a locked log file must not stop the run.
+            }
+        }
+    }
+}

--- a/Spritz/SpritzGUI.Avalonia/Views/MainWindow.axaml
+++ b/Spritz/SpritzGUI.Avalonia/Views/MainWindow.axaml
@@ -1,0 +1,134 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:Spritz.Avalonia.ViewModels"
+        x:Class="Spritz.Avalonia.Views.MainWindow"
+        x:DataType="vm:MainWindowViewModel"
+        Title="Spritz" Width="1000" Height="560">
+
+  <!-- Ported from the WPF MainWindow.xaml. Substitutions Avalonia requires:
+       GroupBox        -> HeaderedContentControl, styled below
+       RichTextBox     -> read-only TextBox; only plain text is ever appended
+       Style.Triggers  -> Avalonia uses selectors, so the cell colouring is dropped for now
+       ToolTip="..."   -> ToolTip.Tip="..." -->
+  <Window.Styles>
+    <Style Selector="HeaderedContentControl">
+      <Setter Property="Template">
+        <ControlTemplate>
+          <Border BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                  BorderThickness="1" CornerRadius="4" Margin="4" Padding="6">
+            <DockPanel>
+              <TextBlock DockPanel.Dock="Top" Text="{TemplateBinding Header}"
+                         FontWeight="SemiBold" Margin="0,0,0,6" />
+              <ContentPresenter Content="{TemplateBinding Content}" />
+            </DockPanel>
+          </Border>
+        </ControlTemplate>
+      </Setter>
+    </Style>
+    <Style Selector="Button">
+      <Setter Property="Margin" Value="3,0" />
+    </Style>
+  </Window.Styles>
+
+  <DockPanel>
+    <Menu DockPanel.Dock="Top">
+      <MenuItem Header="Help">
+        <MenuItem Header="Open Wiki Page" Click="OnWikiClick" />
+        <MenuItem Header="Contact" Click="OnContactClick" />
+      </MenuItem>
+      <MenuItem Header="Settings">
+        <MenuItem>
+          <MenuItem.Header>
+            <StackPanel Orientation="Horizontal">
+              <TextBlock Text="Target Docker image:" VerticalAlignment="Center" Margin="0,0,6,0" />
+              <TextBox Text="{Binding DockerImage}" Width="220"
+                       ToolTip.Tip="A name containing ':' is used as-is; a name without 'smithlab/' is not pulled, so a locally built image is used." />
+            </StackPanel>
+          </MenuItem.Header>
+        </MenuItem>
+      </MenuItem>
+    </Menu>
+
+    <Border DockPanel.Dock="Bottom" Padding="8,4" Background="{DynamicResource SystemControlBackgroundListLowBrush}">
+      <TextBlock Text="{Binding DockerStatus}" TextWrapping="Wrap" />
+    </Border>
+
+    <Grid ColumnDefinitions="*,Auto,*">
+      <Grid Grid.Column="0" RowDefinitions="*,Auto,*">
+
+        <HeaderedContentControl Grid.Row="0" Header="SRA — RNA-seq data from NCBI SRA">
+          <DockPanel>
+            <TextBox DockPanel.Dock="Top" Text="{Binding SraAccession}" Watermark="e.g. SRR13737862" />
+            <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,6">
+              <Button Content="Add paired-end" Command="{Binding AddPairedEndSraCommand}" />
+              <Button Content="Add single-end" Command="{Binding AddSingleEndSraCommand}" />
+              <Button Content="Clear" Command="{Binding ClearSrasCommand}" />
+            </StackPanel>
+            <DataGrid ItemsSource="{Binding Sras}" IsReadOnly="True" AutoGenerateColumns="False">
+              <DataGrid.Columns>
+                <DataGridTextColumn Header="Accession" Binding="{Binding Name}" Width="*" />
+                <DataGridCheckBoxColumn Header="Paired-end" Binding="{Binding IsPairedEnd}" />
+              </DataGrid.Columns>
+            </DataGrid>
+          </DockPanel>
+        </HeaderedContentControl>
+
+        <GridSplitter Grid.Row="1" Height="5" HorizontalAlignment="Stretch" />
+
+        <HeaderedContentControl Grid.Row="2" Header="FASTQ">
+          <DockPanel>
+            <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,6">
+              <Button Content="Add FASTQ files..." Click="OnAddFastqClick" />
+              <Button Content="Clear" Command="{Binding ClearFastqsCommand}" />
+            </StackPanel>
+            <DataGrid ItemsSource="{Binding Fastqs}" IsReadOnly="True" AutoGenerateColumns="False">
+              <DataGrid.Columns>
+                <DataGridTextColumn Header="File" Binding="{Binding FileName}" Width="*" />
+                <DataGridTextColumn Header="Mate" Binding="{Binding MatePair}" />
+                <DataGridCheckBoxColumn Header="Paired-end" Binding="{Binding IsPairedEnd}" />
+              </DataGrid.Columns>
+            </DataGrid>
+          </DockPanel>
+        </HeaderedContentControl>
+      </Grid>
+
+      <GridSplitter Grid.Column="1" Width="5" VerticalAlignment="Stretch" />
+
+      <Grid Grid.Column="2" RowDefinitions="*,Auto,*">
+        <HeaderedContentControl Grid.Row="0" Header="Workflow">
+          <DockPanel>
+            <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,0,0,6">
+              <Button Content="Create workflow..." Click="OnCreateWorkflowClick" />
+            </StackPanel>
+            <DockPanel DockPanel.Dock="Bottom" Margin="0,6,0,0">
+              <TextBlock Text="Analysis directory:" VerticalAlignment="Center" Margin="0,0,6,0" />
+              <Button DockPanel.Dock="Right" Content="Browse..." Click="OnBrowseOutputClick" />
+              <TextBox Text="{Binding OutputFolder}" />
+            </DockPanel>
+            <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Center">
+              <Button Content="Run workflow" Command="{Binding RunWorkflowCommand}"
+                      IsEnabled="{Binding !IsRunning}" />
+              <Button Content="Cancel" Command="{Binding CancelCommand}"
+                      IsEnabled="{Binding IsRunning}" />
+            </StackPanel>
+            <ListBox ItemsSource="{Binding Workflows}">
+              <ListBox.ItemTemplate>
+                <DataTemplate>
+                  <TextBlock Text="{Binding DisplayName}" />
+                </DataTemplate>
+              </ListBox.ItemTemplate>
+            </ListBox>
+          </DockPanel>
+        </HeaderedContentControl>
+
+        <GridSplitter Grid.Row="1" Height="5" HorizontalAlignment="Stretch" />
+
+        <HeaderedContentControl Grid.Row="2" Header="Information">
+          <TextBox Text="{Binding Information}" IsReadOnly="True" AcceptsReturn="True"
+                   TextWrapping="NoWrap" FontFamily="monospace"
+                   VerticalContentAlignment="Top" />
+        </HeaderedContentControl>
+      </Grid>
+    </Grid>
+  </DockPanel>
+</Window>

--- a/Spritz/SpritzGUI.Avalonia/Views/MainWindow.axaml.cs
+++ b/Spritz/SpritzGUI.Avalonia/Views/MainWindow.axaml.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Platform.Storage;
+using Spritz.Avalonia.ViewModels;
+
+namespace Spritz.Avalonia.Views;
+
+/// <summary>
+/// The view holds only what genuinely needs a window: file pickers, opening a browser, and the
+/// workflow dialog. Everything else lives in the view model.
+/// </summary>
+public partial class MainWindow : Window
+{
+    private MainWindowViewModel ViewModel => (MainWindowViewModel)DataContext;
+
+    public MainWindow() => AvaloniaXamlLoader.Load(this);
+
+    /// <summary>
+    /// Avalonia's StorageProvider replaces Microsoft.Win32.OpenFileDialog, which is Windows-only.
+    /// </summary>
+    private async void OnAddFastqClick(object sender, RoutedEventArgs e)
+    {
+        IReadOnlyList<IStorageFile> files = await StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Select FASTQ files",
+            AllowMultiple = true,
+            FileTypeFilter = new[]
+            {
+                new FilePickerFileType("FASTQ") { Patterns = new[] { "*.fastq", "*.fastq.gz" } },
+            },
+        });
+
+        ViewModel.AddFastqFiles(files.Select(f => f.Path.LocalPath));
+    }
+
+    private async void OnBrowseOutputClick(object sender, RoutedEventArgs e)
+    {
+        IReadOnlyList<IStorageFolder> folders = await StorageProvider.OpenFolderPickerAsync(
+            new FolderPickerOpenOptions { Title = "Select the analysis directory", AllowMultiple = false });
+
+        if (folders.Count > 0)
+        {
+            ViewModel.OutputFolder = folders[0].Path.LocalPath;
+        }
+    }
+
+    private async void OnCreateWorkflowClick(object sender, RoutedEventArgs e)
+    {
+        // The workflow dialog is the remaining piece of the port. Until it exists, say so plainly
+        // rather than appearing to work.
+        await ShowMessageAsync("Not yet ported",
+            "The workflow options dialog has not been ported yet. Until it is, build a workflow in the "
+            + "Windows GUI, or run the container directly with SpritzCMD.");
+    }
+
+    private void OnWikiClick(object sender, RoutedEventArgs e) =>
+        OpenUrl("https://github.com/smith-chem-wisc/Spritz/wiki");
+
+    private void OnContactClick(object sender, RoutedEventArgs e) =>
+        OpenUrl("https://github.com/smith-chem-wisc/Spritz/issues");
+
+    /// <summary>Process.Start with UseShellExecute opens the platform's default browser on all three OSes.</summary>
+    private static void OpenUrl(string url)
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+        }
+        catch (Exception)
+        {
+            // Opening a browser is a convenience; failing to do so must not take the window down.
+        }
+    }
+
+    /// <summary>A minimal replacement for WPF's MessageBox, which Avalonia does not provide.</summary>
+    private async System.Threading.Tasks.Task ShowMessageAsync(string title, string message)
+    {
+        var dialog = new Window
+        {
+            Title = title,
+            Width = 420,
+            SizeToContent = SizeToContent.Height,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+        };
+        var ok = new Button { Content = "OK", HorizontalAlignment = global::Avalonia.Layout.HorizontalAlignment.Right };
+        ok.Click += (_, _) => dialog.Close();
+        dialog.Content = new StackPanel
+        {
+            Margin = new global::Avalonia.Thickness(16),
+            Spacing = 12,
+            Children =
+            {
+                new TextBlock { Text = message, TextWrapping = global::Avalonia.Media.TextWrapping.Wrap },
+                ok,
+            },
+        };
+        await dialog.ShowDialog(this);
+    }
+}

--- a/Spritz/SpritzGUI.Avalonia/app.manifest
+++ b/Spritz/SpritzGUI.Avalonia/app.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="Spritz.Desktop"/>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
**Draft**, because #32 - whether to port the GUI or retire it - is still an open decision, and this is
the evidence for the port half rather than a fait accompli.

## Why

The WPF GUI is the only Windows-locked part of Spritz. `SpritzBackend` already targets `net10.0` with
no Windows dependency, and `SpritzCMD` runs *inside* the Linux container. So macOS and Linux users have
no GUI at all today, and the documented commandline route is the fragile host-snakemake one - the path
#243's reporter followed straight into a Windows path bug.

| | lines |
|---|---|
| `SpritzGUI` (WPF) | 1,296 |
| `SpritzBackend`, reused untouched | 539 |
| this port, including 33 tests | ~1,600 |

The model classes in `SpritzGUI/DataGrids` and `SpritzGUI/TreeViews` are **linked, not copied** - they
contain no WPF types, so both front ends compile the same source. If one ever gains a UI dependency,
this build fails and says so.

## Three things improved rather than ported

- **docker is launched directly**, not through `Powershell.exe`, with arguments passed as a list. That
  removes the Windows dependency *and* the reason volume paths are currently interpolated inside
  `"""triple quotes"""` - a path containing a space or a quote no longer needs escaping, because no
  shell parses it. There is a test asserting no argument requires quoting.
- **`StartsWith("smithlab/")`** replaces `Contains("smithlab")`, so a local image named `smithlab-test`
  is no longer pulled over.
- **Docker detection is asynchronous**, reported in the status bar. The WPF window does it in its
  constructor behind a blocking `Dispatcher.Invoke` then a modal dialog, so slow or absent Docker
  delays startup.

## Tests: 33, headless, no display required

Beyond the docker argument construction, these cover the patterns MetaMorpheus's own `Test/GuiTests`
suite covers and my first pass missed - property changes raising notifications (a binding that stops
notifying fails silently), commands refusing preconditions *with a reason*, constructors setting usable
defaults, and bad input being rejected rather than absorbed.

**Mate-pair detection from `_1`/`_2` suffixes is pinned**, because getting it wrong mispairs reads
silently - the failure class behind #237. Verified by mutation: breaking de-duplication and the
output-folder default fails exactly the two tests that should fail.

## CI and releases

A `gui-crossplatform` job builds and tests on **ubuntu, macos and windows** - by project path, not
through `Spritz.sln`. The solution defines only `x64`/`x86` and is built with `/p:Platform=x64`, while
this project sets no `PlatformTarget` deliberately; adding it there would map it to a platform it does
not want.

Releases gain self-contained builds for `win-x64`, `linux-x64`, `osx-arm64` and `osx-x64`, **alongside**
the existing installer. macOS ships as a `.app` bundle, assembled on a macOS runner and archived with
`ditto` so the layout and executable bit survive. Verified locally on arm64:

```
plutil -lint               -> OK
CFBundleShortVersionString -> 0.3.14   (the tag-derived version flows through)
kMDItemContentType         -> com.apple.application-bundle
```

112 MB published, 44 MB compressed, per platform - so releases get noticeably larger.

## Known gaps

- The workflow options dialog is **not ported**; the button says so rather than appearing to work.
- No drag and drop, and no DataGrid cell colouring - that needs Avalonia selectors rather than
  `DataTrigger`.
- **Not signed or notarized**, so macOS warns on first open. That needs Apple credentials and is a
  separate decision.
- The WPF GUI and its installer are untouched and remain the supported Windows download.