### PR TITLE
Use posixpath for workflow paths so the DAG resolves on native Windows

### DIFF
--- a/Spritz/workflow/rules/common.smk
+++ b/Spritz/workflow/rules/common.smk
@@ -1,4 +1,5 @@
 import os
+import posixpath  # snakemake paths are always forward-slash; see the note on all_output
 
 # Variables used by many of the rules
 SPECIES = config["species"]
@@ -64,7 +65,7 @@ CONDA_CA_BUNDLE_EXPORT = (
 def all_output(wildcards):
     '''Gets the final output files depending on the configuration'''
     outputs = ["prose.txt"]
-    outputs.append(os.path.join("variants/", f"done{REF}.{ENSEMBL_VERSION}.txt")) # reference
+    outputs.append(posixpath.join("variants/", f"done{REF}.{ENSEMBL_VERSION}.txt")) # reference
     if "variant" in config["analyses"]:
         outputs.append("final/combined.spritz.snpeff.protein.withmods.xml.gz") # variants
     if "isoform" in config["analyses"]:
@@ -80,7 +81,9 @@ def all_output(wildcards):
             "final/transcript_custom_quant.tpms.csv",
             "final/gene_custom_quant.tpms.csv"]) # isoform quant with stringtie
     expanded_outputs = expand(
-        [os.path.join("{dir}", file) for file in outputs],
+        # posixpath, not os.path: on native Windows os.path.join inserts a backslash, so this
+        # asked for a path no rule declares and the DAG failed before any job ran (issue #243).
+        [posixpath.join("{dir}", file) for file in outputs],
         dir=config["analysis_directory"])
     return expanded_outputs
 

--- a/Spritz/workflow/rules/proteogenomics.smk
+++ b/Spritz/workflow/rules/proteogenomics.smk
@@ -138,17 +138,17 @@ rule reference_protein_xml:
         transfermods=TRANSFER_MOD_DLL,
         unixml=UNIPROTXML,
     output:
-        done=os.path.join("{dir}/variants/", f"done{REF}.{ENSEMBL_VERSION}.txt"),
-        protxml=temp(os.path.join("{dir}/variants/", f"{REF}.{ENSEMBL_VERSION}.protein.xml")),
-        protxmlgz=os.path.join("{dir}/variants/", f"{REF}.{ENSEMBL_VERSION}.protein.xml.gz"),
-        protfa=os.path.join("{dir}/variants/", f"{REF}.{ENSEMBL_VERSION}.protein.fasta"),
-        protwithdecoysfa=os.path.join("{dir}/variants/", f"{REF}.{ENSEMBL_VERSION}.protein.withdecoys.fasta"),
-        protxmlwithmods=temp(os.path.join("{dir}/variants/", f"{REF}.{ENSEMBL_VERSION}.protein.withmods.xml")),
-        protxmlwithmodsgz=os.path.join("{dir}/variants/", f"{REF}.{ENSEMBL_VERSION}.protein.withmods.xml.gz"),
+        done=posixpath.join("{dir}/variants/", f"done{REF}.{ENSEMBL_VERSION}.txt"),
+        protxml=temp(posixpath.join("{dir}/variants/", f"{REF}.{ENSEMBL_VERSION}.protein.xml")),
+        protxmlgz=posixpath.join("{dir}/variants/", f"{REF}.{ENSEMBL_VERSION}.protein.xml.gz"),
+        protfa=posixpath.join("{dir}/variants/", f"{REF}.{ENSEMBL_VERSION}.protein.fasta"),
+        protwithdecoysfa=posixpath.join("{dir}/variants/", f"{REF}.{ENSEMBL_VERSION}.protein.withdecoys.fasta"),
+        protxmlwithmods=temp(posixpath.join("{dir}/variants/", f"{REF}.{ENSEMBL_VERSION}.protein.withmods.xml")),
+        protxmlwithmodsgz=posixpath.join("{dir}/variants/", f"{REF}.{ENSEMBL_VERSION}.protein.withmods.xml.gz"),
     params: ref=REF
     resources: mem_mb=16000
-    benchmark: os.path.join("{dir}/variants/", f"{REF}.{ENSEMBL_VERSION}.spritz.benchmark")
-    log: os.path.join("{dir}/variants/", f"{REF}.{ENSEMBL_VERSION}.spritz.log")
+    benchmark: posixpath.join("{dir}/variants/", f"{REF}.{ENSEMBL_VERSION}.spritz.benchmark")
+    log: posixpath.join("{dir}/variants/", f"{REF}.{ENSEMBL_VERSION}.spritz.log")
     conda: "../envs/proteogenomics.yaml"
     shell:
         "(java -Xmx{resources.mem_mb}M -jar {input.snpeff} -v -nostats"

--- a/Spritz/workflow/rules/variants.smk
+++ b/Spritz/workflow/rules/variants.smk
@@ -239,17 +239,17 @@ rule finish_variants:
         protfa="{dir}/variants/combined.spritz.snpeff.protein.fasta",
         protwithdecoysfa="{dir}/variants/combined.spritz.snpeff.protein.withdecoys.fasta",
         protxmlwithmodsgz="{dir}/variants/combined.spritz.snpeff.protein.withmods.xml.gz",
-        refprotfa=os.path.join("{dir}/variants/", f"{REF}.{ENSEMBL_VERSION}.protein.fasta"),
-        refprotwithdecoysfa=os.path.join("{dir}/variants/", f"{REF}.{ENSEMBL_VERSION}.protein.withdecoys.fasta"),
-        refprotwithmodsxml=os.path.join("{dir}/variants/", f"{REF}.{ENSEMBL_VERSION}.protein.withmods.xml.gz"),
+        refprotfa=posixpath.join("{dir}/variants/", f"{REF}.{ENSEMBL_VERSION}.protein.fasta"),
+        refprotwithdecoysfa=posixpath.join("{dir}/variants/", f"{REF}.{ENSEMBL_VERSION}.protein.withdecoys.fasta"),
+        refprotwithmodsxml=posixpath.join("{dir}/variants/", f"{REF}.{ENSEMBL_VERSION}.protein.withmods.xml.gz"),
     output:
         ann="{dir}/final/combined.spritz.snpeff.vcf",
         protfa="{dir}/final/combined.spritz.snpeff.protein.fasta",
         protwithdecoysfa="{dir}/final/combined.spritz.snpeff.protein.withdecoys.fasta",
         protxmlwithmodsgz="{dir}/final/combined.spritz.snpeff.protein.withmods.xml.gz",
-        refprotfa=os.path.join("{dir}/final/", f"{REF}.{ENSEMBL_VERSION}.protein.fasta"),
-        refprotwithdecoysfa=os.path.join("{dir}/final/", f"{REF}.{ENSEMBL_VERSION}.protein.withdecoys.fasta"),
-        refprotwithmodsxml=os.path.join("{dir}/final/", f"{REF}.{ENSEMBL_VERSION}.protein.withmods.xml.gz"),
+        refprotfa=posixpath.join("{dir}/final/", f"{REF}.{ENSEMBL_VERSION}.protein.fasta"),
+        refprotwithdecoysfa=posixpath.join("{dir}/final/", f"{REF}.{ENSEMBL_VERSION}.protein.withdecoys.fasta"),
+        refprotwithmodsxml=posixpath.join("{dir}/final/", f"{REF}.{ENSEMBL_VERSION}.protein.withmods.xml.gz"),
     log: "{dir}/variants/finish_isoform_variants.log"
     conda: "../envs/proteogenomics.yaml"
     shell:


### PR DESCRIPTION
🤖

Fixes #243.

## Root cause

`common.smk` built rule `all`'s inputs with `os.path.join`. On native Windows that inserts a
backslash:

```
rule all asks for   G:\Spritz\variants/doneHomo_sapiens.GRCh38.103.txt
the rule declares   "{dir}/variants/doneHomo_sapiens.GRCh38.103.txt"
which expands to    G:\Spritz/variants/doneHomo_sapiens.GRCh38.103.txt
```

Snakemake matches inputs to outputs **as strings**, so those never match and the DAG fails before any
job runs — which is exactly why the reporter saw the exception immediately rather than partway
through a run. The thread guessed at a corrupted workflow folder and suggested WSL; that guess was
wrong, and the reporter was left without a fix for four months.

## The change

Snakemake paths are always forward-slash, so `os.path` is the wrong tool for building them. All **17**
`os.path.join` calls in the rule files become `posixpath.join` — identical on Linux and in the
container, correct on Windows.

`variants.smk` and `proteogenomics.smk` had the same pattern in `output`, `benchmark` and `log` paths,
so they would have failed immediately after this one was fixed. The `os.path.join` uses in
`scripts/` and `tests/` are left alone: those are real filesystem paths, where `os.path` is right.

## Verification

Simulated Windows semantics with `ntpath`, since I can't run native Windows here:

| | rule `all` input vs declared output |
|---|---|
| before | **differ** — reproduces the reporter's mixed separators character for character |
| after | **match** |

The 56 workflow script tests still pass. CI's `--lint` and the five `--dry-run` jobs cover the
snakemake side on Linux, where behaviour is unchanged by construction.

## Worth deciding separately

Whether native Windows is a supported way to run the workflow at all. The wiki documents the
commandline usage this reporter followed, while the GUI runs everything through the Linux container.
This fix is cheap and correct either way, but if Windows isn't meant to be supported the wiki should
say so plainly rather than leaving people to discover it through a `MissingInputException`.