### PR TITLE
Stop unknown-residue entries leaving orphan decoys in withdecoys.fasta

### DIFF
--- a/Spritz/SpritzModifications/ProteinAnnotation.cs
+++ b/Spritz/SpritzModifications/ProteinAnnotation.cs
@@ -28,6 +28,46 @@ namespace SpritzModifications
         /// <summary>
         /// Transfers likely modifications from a list of proteins to another based on sequence similarity. Returns a list of new objects.
         /// </summary>
+        /// <summary>
+        /// Drops entries whose C-terminal residue is unknown, from a list holding both targets and decoys, so
+        /// that the database keeps one decoy per target.
+        ///
+        /// Testing "ends with '?'" against a decoy never matches: reversal moves the unknown residue to the
+        /// front of the sequence, keeping an initiator methionine in place. So the plain test removed the
+        /// target and kept its decoy, which is what left more decoys than targets in withdecoys.fasta
+        /// (issue #220). Unpaired decoys enlarge the decoy search space that false discovery rates are
+        /// estimated against.
+        ///
+        /// The unknown residue has to be found in whichever orientation the entry is written, rather than by
+        /// generating decoys from filtered targets: mzLib's decoy generator reverses sequence variations
+        /// against the consensus sequence, so it must be handed non-variant proteins, and the proteins here
+        /// have already had their variants applied.
+        /// </summary>
+        public static List<Protein> DropEntriesWithUnknownCTerminus(IEnumerable<Protein> targetsAndDecoys)
+        {
+            return targetsAndDecoys.Where(p => !HasUnknownCTerminus(p)).ToList();
+        }
+
+        private static bool HasUnknownCTerminus(Protein protein)
+        {
+            string sequence = protein.BaseSequence;
+            if (sequence.Length == 0)
+            {
+                return false;
+            }
+
+            if (!protein.IsDecoy)
+            {
+                return sequence.EndsWith('?');
+            }
+
+            // reversal holds an initiator methionine in place, so the target's final residue lands at index 1
+            // when the sequence starts with M, and at index 0 otherwise
+            int indexOfTargetCTerminus = sequence.StartsWith('M') ? 1 : 0;
+
+            return sequence.Length > indexOfTargetCTerminus && sequence[indexOfTargetCTerminus] == '?';
+        }
+
         /// <param name="proteogenomicProteins"></param>
         /// <param name="uniprotProteins"></param>
         /// <returns></returns>

--- a/Spritz/SpritzModifications/SpritzModifications.cs
+++ b/Spritz/SpritzModifications/SpritzModifications.cs
@@ -113,7 +113,8 @@ namespace SpritzModifications
             string outfastaWithDecoys = Path.Combine(Path.GetDirectoryName(destinationXmlPath), Path.GetFileNameWithoutExtension(destinationXmlPath) + ".withdecoys.fasta");
             var prot = newProts.FirstOrDefault(p => p.Accession.Contains("_"));
             var protsForFasta = newProts.SelectMany(p => p.GetVariantBioPolymers(maxAllowedVariantsForCombinatorics: 4, minAlleleDepth: 1)).Where(p => !p.BaseSequence.EndsWith('?')).ToList();
-            var decoyProtsForFasta = ProteinDbLoader.LoadProteinXML(destinationXmlPath, true, DecoyType.Reverse, uniprotPtms, false, null, out un).Where(p => !p.BaseSequence.EndsWith('?')).ToList();
+            var decoyProtsForFasta = ProteinAnnotation.DropEntriesWithUnknownCTerminus(
+                ProteinDbLoader.LoadProteinXML(destinationXmlPath, true, DecoyType.Reverse, uniprotPtms, false, null, out un));
             ProteinDbWriter.WriteFastaDatabase(protsForFasta, outfasta, "|");
             ProteinDbWriter.WriteFastaDatabase(decoyProtsForFasta, outfastaWithDecoys, "|");
             File.WriteAllLines(outfastaWithDecoys, File.ReadAllLines(outfastaWithDecoys).Select(line => line.Replace("mz|DECOY_", "rev_mz|")));

--- a/Spritz/SpritzTest/DecoyTargetParityTests.cs
+++ b/Spritz/SpritzTest/DecoyTargetParityTests.cs
@@ -1,0 +1,70 @@
+using NUnit.Framework;
+using Proteomics;
+using SpritzModifications;
+using System.Collections.Generic;
+using System.Linq;
+using UsefulProteomicsDatabases;
+
+namespace SpritzTest
+{
+    /// <summary>
+    /// The target-decoy database has to hold one decoy per target. Issue #220 reported 90,584 decoys against
+    /// 90,268 targets, meaning some decoys had no target counterpart and the decoy search space that false
+    /// discovery rates are estimated against was larger than the target space it is meant to mirror.
+    /// </summary>
+    public class DecoyTargetParityTests
+    {
+        private static List<Protein> WithDecoys(params string[] sequences)
+        {
+            var targets = sequences.Select((s, i) => new Protein(s, "acc" + i)).ToList();
+
+            return targets.Concat(DecoyProteinGenerator.GenerateDecoys(targets, DecoyType.Reverse)).ToList();
+        }
+
+        [Test]
+        public void DropEntriesWithUnknownCTerminus_KeepsCompleteEntriesPaired()
+        {
+            var kept = ProteinAnnotation.DropEntriesWithUnknownCTerminus(WithDecoys("MPEPTIDEK", "MPEPTIDER", "SEQUENCEK"));
+
+            Assert.That(kept.Count(p => !p.IsDecoy), Is.EqualTo(3));
+            Assert.That(kept.Count(p => p.IsDecoy), Is.EqualTo(3));
+        }
+
+        /// <summary>
+        /// The regression. An entry whose C-terminal residue is unknown is dropped, and its decoy has to go
+        /// with it even though the decoy does not end in '?' - reversal moved that residue to the front.
+        /// Covers both the initiator-methionine case and the case without one, since the two put the reversed
+        /// C-terminus at different indices.
+        /// </summary>
+        [Test]
+        public void DropEntriesWithUnknownCTerminus_DropsBothHalvesOfAnIncompleteEntry()
+        {
+            var kept = ProteinAnnotation.DropEntriesWithUnknownCTerminus(
+                WithDecoys("MPEPTIDEK", "MPEPTIDE?", "SEQUENCE?"));
+
+            Assert.That(kept.Count(p => !p.IsDecoy), Is.EqualTo(1), "only the complete target survives");
+            Assert.That(kept.Count(p => p.IsDecoy), Is.EqualTo(1), "the incomplete entries must not leave decoys behind");
+            Assert.That(kept.Select(p => p.BaseSequence), Has.None.Contains("?"),
+                "no unknown residue should reach the database in either orientation");
+        }
+
+        /// <summary>
+        /// Pins the assumption the filter rests on. If mzLib ever stops holding the initiator methionine in
+        /// place, or reverses differently, this fails rather than silently unbalancing the database again.
+        /// </summary>
+        [Test]
+        public void ReversalMovesTheUnknownResidueOffTheCTerminus()
+        {
+            var decoys = DecoyProteinGenerator.GenerateDecoys(
+                new List<Protein> { new Protein("MPEPTIDE?", "withM"), new Protein("SEQUENCE?", "withoutM") },
+                DecoyType.Reverse);
+
+            var withM = decoys.Single(p => p.Accession.Contains("withM"));
+            var withoutM = decoys.Single(p => p.Accession.Contains("withoutM"));
+
+            Assert.That(withM.BaseSequence.EndsWith('?'), Is.False);
+            Assert.That(withM.BaseSequence[1], Is.EqualTo('?'), "held methionine puts the reversed C-terminus at index 1");
+            Assert.That(withoutM.BaseSequence[0], Is.EqualTo('?'), "without a methionine it lands at index 0");
+        }
+    }
+}


### PR DESCRIPTION
🤖 Closes #220.

An entry whose C-terminal residue is unknown was dropped from `withdecoys.fasta` while its decoy stayed behind, leaving a decoy with no target.

`DropEntriesWithUnknownCTerminus` — previously a plain `EndsWith('?')` filter — ran over a list holding both targets and decoys. Testing "ends with `?`" never matches a decoy: reversal moves the unknown residue to the front, holding an initiator methionine in place. So the filter removed the target and kept its decoy, which is one of the ways the database ended up with more decoys than targets.

The filter now finds the unknown residue in whichever orientation the entry is written, so an incomplete entry takes its decoy with it and no `?` reaches the database in either orientation.

## The rest of #220 is fixed in mzLib, and needs a version bump here

This change accounts for **3 of the 340** surplus decoy entries on a U2OS Spritz database. The remainder was in mzLib's variant decoy generation, and is fixed by **smith-chem-wisc/mzLib#1154**, which takes that same database from 96,425 targets against 96,762 decoys to **96,425 against 96,425** — every decoy a composition-preserving reversal of exactly one target, no target left without one.

So the issue is resolved across two changes, and **Spritz users will not see the decoy counts balance until the `mzLib` `PackageReference` here is bumped to a release containing that fix.** Sequence for anyone following along:

1. merge smith-chem-wisc/mzLib#1154
2. tag an mzLib release
3. bump `mzLib` in `SpritzModifications.csproj` (currently 1.0.584)
4. regenerate a database and confirm the counts

Closing #220 on this PR per maintainer preference, since the issue is filed here and its cause is now understood and fixed in both places. Step 3 is the one that still has to happen for a user's output to change, and it is worth not losing sight of.

## Why the filter is not simply applied before generating decoys

That would be tidier, and it crashes. mzLib's decoy generator reverses sequence variations against the consensus sequence, so it must be handed non-variant proteins — and the proteins here have already had their variants applied. Feeding it variant-applied entries throws `ArgumentOutOfRangeException` from inside `ReverseSequenceVariations`. I tried that first and it failed on real data, which is why the filter works on the loaded target-and-decoy list instead.

That crash is also fixed in the mzLib PR above, but nothing here depends on it.

## Tests

Three in `SpritzTest/DecoyTargetParityTests.cs`:

- complete entries stay paired
- an incomplete entry takes both of its halves with it, covering the initiator-methionine case and the case without one, since reversal puts the unknown residue at different indices
- an oracle pinning mzLib's reversal convention, so that a change to it fails loudly here rather than silently unbalancing the database again

46/46 pass locally (`Category!=ExternalService`, net10.0, arm64).
